### PR TITLE
Statfactor output

### DIFF
--- a/bng2/BNG2.pl
+++ b/bng2/BNG2.pl
@@ -93,7 +93,8 @@ my %default_args         = ( 'write_xml'     => 0,  'write_mfile'      => 0,
                              'skip_actions'  => 0,  'action_skip_warn' => 1,
                              'logging'       => 0,  'no_exec'          => 0,
                              'allow_perl'    => 0,  'no_nfsim'         => 0,
-                             'output_dir'    => File::Spec->curdir()
+                             'output_dir'    => File::Spec->curdir(),
+							 'write_autos'   => 0
                            );
 # Default params for Console mode
 my %default_args_console = ( 'write_xml'     => 0,  'write_mfile'      => 0,
@@ -101,7 +102,8 @@ my %default_args_console = ( 'write_xml'     => 0,  'write_mfile'      => 0,
                              'skip_actions'  => 1,  'action_skip_warn' => 1,
                              'logging'       => 0,  'no_exec'          => 0,
                              'allow_perl'    => 0,  'no_nfsim'         => 0,
-                             'output_dir'    => File::Spec->curdir()
+                             'output_dir'    => File::Spec->curdir(),
+							 'write_autos'   => 0
                            );
 
 
@@ -129,7 +131,8 @@ GetOptions( \%user_args,
             'generate_network|netgen',
             'write_SBML|sbml',
             'write_mfile|mfile',
-            'write_xml|xml'
+            'write_xml|xml',
+			'write_autos|autos'
           )
 or die "Error in command line arguments (try: BNG2.pl --help)";
 

--- a/bng2/Perl2/BNGModel.pm
+++ b/bng2/Perl2/BNGModel.pm
@@ -2395,6 +2395,30 @@ sub generate_network
     # Print result to netfile
     my $err = $model->writeNetwork($params_writeNetwork);
     if ($err) { return $err; }
+	
+	# STATISTICAL FACTOR - DEBUGGING
+	# OUTPUTS A FILE FOR EACH RULE 
+	# SHOWING REACTION INSTANCES AND LUMPING
+	# NAME YOUR RULES FIRST!
+	# - JOHN SEKAR
+	my $aut = 0;
+	if($aut==1)
+	{
+	foreach my $rxn(@{$model->RxnList->Array})
+		{
+		my $str = $rxn->toString(1);
+		my %inst = %{$rxn->InstanceHash};
+		my @k = keys %inst;
+		foreach my $rule(@k)
+			{
+			open(my $autfile,">>",$rule.".txt") or die "Not found!";
+			print $autfile "\nReaction\n".$str;
+			print $autfile "\nLumpFactor ".$inst{$rule};
+			print $autfile "\nReactionStatFactor: RuleStatFactor*LumpFactor = ".$rxn->StatFactor."\n";
+			close($autfile);
+			}
+		}
+	}
 
     return '';
 

--- a/bng2/Perl2/BNGModel.pm
+++ b/bng2/Perl2/BNGModel.pm
@@ -2396,12 +2396,14 @@ sub generate_network
     my $err = $model->writeNetwork($params_writeNetwork);
     if ($err) { return $err; }
 	
-	# STATISTICAL FACTOR - DEBUGGING
+	# STATISTICAL FACTOR FOR REACTIONS- DEBUGGING
 	# OUTPUTS A FILE FOR EACH RULE 
 	# SHOWING REACTION INSTANCES AND LUMPING
+	# DURING generate_network()
 	# NAME YOUR RULES FIRST!
 	# - JOHN SEKAR
-	my $aut = 0;
+	
+	my $aut = $BNGModel::GLOBAL_MODEL->Params->{'write_autos'};
 	if($aut==1)
 	{
 	foreach my $rxn(@{$model->RxnList->Array})

--- a/bng2/Perl2/Rxn.pm
+++ b/bng2/Perl2/Rxn.pm
@@ -28,6 +28,7 @@ struct Rxn => {
   RxnRule        => '$',         # RxnRule that generated this Rxn
   RxnRuleArray   => '@',         # Stores all RxnRules that generate this Rxn (can be more than one)
   Index          => '$',         # Reaction Index for writing network output
+  InstanceHash   => '$',		 # Keeps track of instances generated from rules. (#John Sekar)
 };
 
 

--- a/bng2/Perl2/RxnList.pm
+++ b/bng2/Perl2/RxnList.pm
@@ -88,6 +88,9 @@ sub add
                 {
                 	    $rxn2->StatFactor( $rxn2->StatFactor + $rxn->StatFactor );
                 	    $add_rxn = 0;
+						
+						# For write_autos output - John Sekar 
+						++$rxn2->InstanceHash->{$rxn2->RxnRule->Name};
                 	    
                 	    # Check if different rules are generating the same rxn 
                 	   	if ($rxn->RxnRule != $rxn2->RxnRule){
@@ -152,6 +155,9 @@ sub add
     # Add new entry
     if ($add_rxn)
     {
+		# For write_autos output - John Sekar 
+		++$rxn2->InstanceHash->{$rxn2->RxnRule->Name};
+		
         push @{ $rlist->Array }, $rxn;
         $rxn->Index(scalar @{$rlist->Array});
         push @{ $rlist->Hash->{$rstring} }, $rxn;

--- a/bng2/Perl2/RxnList.pm
+++ b/bng2/Perl2/RxnList.pm
@@ -156,7 +156,7 @@ sub add
     if ($add_rxn)
     {
 		# For write_autos output - John Sekar 
-		++$rxn2->InstanceHash->{$rxn2->RxnRule->Name};
+		++$rxn->InstanceHash->{$rxn->RxnRule->Name};
 		
         push @{ $rlist->Array }, $rxn;
         $rxn->Index(scalar @{$rlist->Array});

--- a/bng2/Perl2/RxnRule.pm
+++ b/bng2/Perl2/RxnRule.pm
@@ -2824,9 +2824,8 @@ sub findMap
 	# NAME YOUR RULES FIRST!
 	# - JOHN SEKAR
 	
-	my $aut = 0; 
+	my $aut = $BNGModel::GLOBAL_MODEL->Params->{'write_autos'};
 	my $autfile;
-	
 	if($aut==1) 
 	{
 		my $name = $rr->Name.".txt";

--- a/bng2/Perl2/RxnRule.pm
+++ b/bng2/Perl2/RxnRule.pm
@@ -2037,7 +2037,7 @@ sub findMap
 	my $rr     = shift @_;    # reaction rule
 	my $mtlist = shift @_;    # molecule-types list
 	
-	my $aut = 0; # write automorphism calculations as output for each rule
+	my $aut = 1; # write automorphism calculations as output for each rule
 	# added by John Sekar 11/17/2015
 	my $autfile;
 	if($aut) 
@@ -2884,7 +2884,7 @@ sub findMap
 	{
 		print $autfile "\n1/StatFactor = (|RG|/|Stab|)*|Crg| = ".$multinv."\n";
 		print $autfile "StatFactor = ".$multScale."\n";
-		close($aut);
+		close($autfile);
 	}
 	
 	## debug symmetry output
@@ -2974,10 +2974,14 @@ sub initializeRule
 	    my $species_list = shift @_;          # apply rules with these new species
 	    my $model        = shift @_;          # model
         my $user_params  = (@_) ? shift : {};
+		
+		# for write_autos
 
 	    # overwrite defaults with user params
 	    while ( my ($opt,$val) = each %$user_params )
 	    {   $params->{$opt} = $val;   }
+		
+	
 
         # define return values
         my $err = undef;


### PR DESCRIPTION
Outputs automorphism calculations for each rule. If generate_network() is called in the model, outputs lumping factors for each reaction generated from each rule.

USAGE:
perl BNG2.pl model.bngl --write_autos
(or)
perl BNG2.pl model.bngl --autos