### PR TITLE
Changes to SBML export

### DIFF
--- a/bng2/Perl2/BNGOutput.pm
+++ b/bng2/Perl2/BNGOutput.pm
@@ -956,6 +956,15 @@ sub writeSBML
 #      <compartment id="cell" size="1"/>
 #    </listOfCompartments>
 #EOF
+  # Default units
+  print $SBML "    <listOfUnitDefinitions>\n";
+  print $SBML "      <unitDefinition id=\"substance\" name=\"substance\">\n";
+  print $SBML "        <listOfUnits>\n";
+  print $SBML "          <unit kind=\"item\" exponent=\"1\" multiplier=\"1\"/>\n";
+  print $SBML "        </listOfUnits>\n";
+  print $SBML "      </unitDefinition>\n";
+  print $SBML "    </listOfUnitDefinitions>\n";
+
 	
 	if ($model->CompartmentList->Used) { # @a is not empty...
         print $SBML "    <listOfCompartments>\n";
@@ -1001,7 +1010,8 @@ sub writeSBML
         else{
         		$compartmentString = "cell";
         }
-		printf $SBML "      <species id=\"S%d\" compartment=\"%s\" initialConcentration=\"%.8g\"",
+    printf $SBML "      <species id=\"S%d\" compartment=\"%s\" initialAmount=\"%.8g\"",
+    # printf $SBML "      <species id=\"S%d\" compartment=\"%s\" initialConcentration=\"%.8g\"",
 		                                                                $spec->Index, $compartmentString, $conc;
 
 		if ( $spec->SpeciesGraph->Fixed )
@@ -1152,7 +1162,14 @@ sub writeSBML
 		}
 		
 		print $SBML "        <kineticLaw>\n";
-		my ( $rstring, $err ) = $rxn->RateLaw->toMathMLString( \@rindices, \@pindices, $rxn->StatFactor );
+
+    # pulling the compartment name
+    my $comp_name = undef;
+    my $err = undef;
+    my $rstring = undef;
+    ($comp_name, $err) = $rxn->get_comp_name($BNGModel::GLOBAL_MODEL);
+
+		( $rstring, $err ) = $rxn->RateLaw->toMathMLString( \@rindices, \@pindices, $rxn->StatFactor, $comp_name );
 		if ($err) { return $err; }
 
 		foreach my $line ( split "\n", $rstring )

--- a/bng2/Perl2/BNGOutput.pm
+++ b/bng2/Perl2/BNGOutput.pm
@@ -956,6 +956,7 @@ sub writeSBML
 #      <compartment id="cell" size="1"/>
 #    </listOfCompartments>
 #EOF
+  
   # Default units
   print $SBML "    <listOfUnitDefinitions>\n";
   print $SBML "      <unitDefinition id=\"substance\" name=\"substance\">\n";

--- a/bng2/Perl2/BNGOutput.pm
+++ b/bng2/Perl2/BNGOutput.pm
@@ -1166,10 +1166,10 @@ sub writeSBML
 
     # pulling the compartment name
     my $comp_name = undef;
-    my $vol_expr = undef;
+    my $conv_expr = undef;
     my $err = undef;
     my $rstring = undef;
-    ($vol_expr, $comp_name, $err) = $rxn->get_intensive_to_extensive_units_conversion($BNGModel::GLOBAL_MODEL);
+    ($conv_expr, $comp_name, $err) = $rxn->get_intensive_to_extensive_units_conversion($BNGModel::GLOBAL_MODEL);
 
 		( $rstring, $err ) = $rxn->RateLaw->toMathMLString( \@rindices, \@pindices, $rxn->StatFactor, $comp_name );
 		if ($err) { return $err; }

--- a/bng2/Perl2/BNGOutput.pm
+++ b/bng2/Perl2/BNGOutput.pm
@@ -1166,9 +1166,10 @@ sub writeSBML
 
     # pulling the compartment name
     my $comp_name = undef;
+    my $vol_expr = undef;
     my $err = undef;
     my $rstring = undef;
-    ($comp_name, $err) = $rxn->get_comp_name($BNGModel::GLOBAL_MODEL);
+    ($vol_expr, $comp_name, $err) = $rxn->get_intensive_to_extensive_units_conversion($BNGModel::GLOBAL_MODEL);
 
 		( $rstring, $err ) = $rxn->RateLaw->toMathMLString( \@rindices, \@pindices, $rxn->StatFactor, $comp_name );
 		if ($err) { return $err; }

--- a/bng2/Perl2/RateLaw.pm
+++ b/bng2/Perl2/RateLaw.pm
@@ -1282,7 +1282,7 @@ sub toMathMLString
     my $rindices   = shift;
     my $pindices   = shift;
     my $statFactor = (@_) ? shift : 1;
-    my $comp_name = (@_) ? shift : undef;
+    my $comp_name  = (@_) ? shift : undef;
     my $string     = '';
 
     my @k    = @{ $rl->Constants };
@@ -1291,6 +1291,7 @@ sub toMathMLString
     $string .= "<math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n";
 
     $statFactor *= $rl->Factor;
+
 
 #	if ( $type eq "Ele" )
     if ( $type eq "Ele" | $type eq "Function" )
@@ -1311,12 +1312,8 @@ sub toMathMLString
         {
             $string .= "    <ci> $comp_name </ci>\n";
         }
-
-        $string .= "  </apply>\n";
         # done adding volume correction
-        
-        # debugging
-        # print $string;
+        $string .= "  </apply>\n";
     }
     elsif ( $type eq 'Sat' )
     {

--- a/bng2/Perl2/RateLaw.pm
+++ b/bng2/Perl2/RateLaw.pm
@@ -1282,7 +1282,6 @@ sub toMathMLString
     my $rindices   = shift;
     my $pindices   = shift;
     my $statFactor = (@_) ? shift : 1;
-    # SBML changes
     my $comp_name = (@_) ? shift : undef;
     my $string     = '';
 
@@ -1303,12 +1302,11 @@ sub toMathMLString
             $string .= "    <cn> $statFactor </cn>\n";
         }
         $string .= sprintf "    <ci> %s </ci>\n", $k[0];
-        # we need to get the order of rxn
         for my $i (@$rindices)
         {
             $string .= sprintf "    <ci> S%d </ci>\n", $i;
         }
-        # add volume correction
+        # add volume correction if given
         if ( defined $comp_name )
         {
             $string .= "    <ci> $comp_name </ci>\n";

--- a/bng2/Perl2/RateLaw.pm
+++ b/bng2/Perl2/RateLaw.pm
@@ -1282,6 +1282,8 @@ sub toMathMLString
     my $rindices   = shift;
     my $pindices   = shift;
     my $statFactor = (@_) ? shift : 1;
+    # SBML changes
+    my $comp_name = (@_) ? shift : undef;
     my $string     = '';
 
     my @k    = @{ $rl->Constants };
@@ -1301,11 +1303,22 @@ sub toMathMLString
             $string .= "    <cn> $statFactor </cn>\n";
         }
         $string .= sprintf "    <ci> %s </ci>\n", $k[0];
+        # we need to get the order of rxn
         for my $i (@$rindices)
         {
             $string .= sprintf "    <ci> S%d </ci>\n", $i;
         }
+        # add volume correction
+        if ( defined $comp_name )
+        {
+            $string .= "    <ci> $comp_name </ci>\n";
+        }
+
         $string .= "  </apply>\n";
+        # done adding volume correction
+        
+        # debugging
+        # print $string;
     }
     elsif ( $type eq 'Sat' )
     {

--- a/bng2/Perl2/Rxn.pm
+++ b/bng2/Perl2/Rxn.pm
@@ -136,19 +136,14 @@ sub get_intensive_to_extensive_units_conversion
         my @surfaces = ( grep {$_->SpatialDimensions==2} @reactant_compartments );
         my @volumes  = ( grep {$_->SpatialDimensions==3} @reactant_compartments );
       
-        # compartment determination
-        if ( @volumes ) 
-        {   # volumes take precedence over surfaces
-            # TODO: potential error checks here?
-            # assuming everything is in the same comp
-            $comp_name = $volumes[0]->Name;
-        } 
-        else 
-        {   # this is a surface only reaction
-            # assuming everything is in the same comp
-            $comp_name = $surfaces[0]->Name;
+        if (@surfaces) 
+        {   # TODO: check for consistency for both
+            $comp_name = @surfaces[0]->Name;
         }
-
+        elsif (@volumes)
+        {
+            $comp_name = @volumes[0]->Name;
+        }
         # Pick and toss an anchor reactant.  If there's a surface reactant, toss it.
         # Otherwise toss a volume.
         (@surfaces) ? shift @surfaces : shift @volumes;

--- a/bng2/Perl2/Rxn.pm
+++ b/bng2/Perl2/Rxn.pm
@@ -203,7 +203,6 @@ sub get_comp_name
     my @reactant_compartments = grep {defined $_} (map {$_->SpeciesGraph->Compartment} @{$rxn->Reactants});
     my @product_compartments  = grep {defined $_} (map {$_->SpeciesGraph->Compartment} @{$rxn->Products});
    
-    # return undefined volume expr if there are no compartments
     if ( @reactant_compartments )
     {   # order >=1 reactions
         # divide into surfaces and volumes
@@ -230,11 +229,12 @@ sub get_comp_name
             }
             else
             {   # TODO: return error?
+                # we still need a comparment name
                 $comp_name = $comp1->Name;
             }
         } 
         else 
-        { # this is a surface only reaction
+        {   # this is a surface only reaction
             # check if products are in the same compartment
             my $consistent = 1;
             my $comp1 = $surfaces[0];

--- a/bng2/Perl2/Rxn.pm
+++ b/bng2/Perl2/Rxn.pm
@@ -191,6 +191,135 @@ sub get_intensive_to_extensive_units_conversion
 ###
 
 
+sub get_comp_name
+# ($comp_name, $err) = $rxn->get_comp_name($model)
+{
+    my ($rxn, $model)  = @_;
+
+    my $err;
+    my $comp_name = undef;
+
+    # get all the defined compartments
+    my @reactant_compartments = grep {defined $_} (map {$_->SpeciesGraph->Compartment} @{$rxn->Reactants});
+    my @product_compartments  = grep {defined $_} (map {$_->SpeciesGraph->Compartment} @{$rxn->Products});
+   
+    # return undefined volume expr if there are no compartments
+    if ( @reactant_compartments )
+    {   # order >=1 reactions
+        # divide into surfaces and volumes
+        my @surfaces = ( grep {$_->SpatialDimensions==2} @reactant_compartments );
+        my @volumes  = ( grep {$_->SpatialDimensions==3} @reactant_compartments );
+        
+        if ( @volumes ) 
+        {   # we have at least one volume 
+            # check if products are in the same compartment
+            my $consistent = 1;
+            my $comp1 = $volumes[0];
+            foreach my $comp2 ( @volumes[1..$#reactant_compartments] )
+            {
+                unless ($comp1 == $comp2)
+                {
+                    $consistent = 0;
+                    last;
+                }
+            }
+            if ($consistent)
+            {   # everything in same volume
+                # return volume name
+                $comp_name = $comp1->Name;
+            }
+            else
+            {   # TODO: return error?
+                $comp_name = $comp1->Name;
+            }
+        } 
+        else 
+        { # this is a surface only reaction
+            # check if products are in the same compartment
+            my $consistent = 1;
+            my $comp1 = $surfaces[0];
+            foreach my $comp2 ( @surfaces[1..$#reactant_compartments] )
+            {
+                unless ($comp1 == $comp2)
+                {
+                    $consistent = 0;
+                    last;
+                }
+            }
+            if ($consistent)
+            {   # everything in same volume
+                # return volume name
+                $comp_name = $comp1->Name;
+            }
+            else
+            {   # TODO: return error?
+                $comp_name = $comp1->Name;
+            }
+        }
+
+    }
+    elsif ( @product_compartments>0 )
+    {   # zero-order reactions
+        my @surfaces = ( grep {$_->SpatialDimensions==2} @product_compartments );
+        my @volumes  = ( grep {$_->SpatialDimensions==3} @product_compartments );
+        
+        if ( @volumes ) 
+        {   # we have at least one volume 
+            # check if products are in the same compartment
+            my $consistent = 1;
+            my $comp1 = $volumes[0];
+            foreach my $comp2 ( @volumes[1..$#product_compartments] )
+            {
+                unless ($comp1 == $comp2)
+                {
+                    $consistent = 0;
+                    last;
+                }
+            }
+            if ($consistent)
+            {   # everything in same volume
+                # return volume name
+                $comp_name = $comp1->Name;
+            }
+            else
+            {   # TODO: return error?
+                $comp_name = $comp1->Name;
+            }
+        } 
+        else 
+        { # this is a surface only reaction
+            # check if products are in the same compartment
+            my $consistent = 1;
+            my $comp1 = $surfaces[0];
+            foreach my $comp2 ( @surfaces[1..$#product_compartments] )
+            {
+                unless ($comp1 == $comp2)
+                {
+                    $consistent = 0;
+                    last;
+                }
+            }
+            if ($consistent)
+            {   # everything in same volume
+                # return volume name
+                $comp_name = $comp1->Name;
+            }
+            else
+            {   # TODO: return error?
+                $comp_name = $comp1->Name;
+            }
+        }
+    }
+    # return the expression (possibly undefined) and the error msg (if any).
+    return $comp_name, $err;
+}
+
+
+###
+###
+###
+
+
 sub getCVodeName
 {
     my $rxn = shift;


### PR DESCRIPTION
The SBML exporting for compartmental models was not incorrect. The SBML export needed to include the compartment the reaction takes place in the kinetic law of SBML. After this merge the species counts time series matches BNG results, tested with COPASI and libRoadRunner. 

Additionally, the initial amounts are now given in counts instead of as concentration and the global SBML unit is changed to counts as well. 

This merge changes the subroutine `get_intensive_to_extensive_units_conversion` of `Rxn` object a bit to return the compartment the reaction takes place and uses the subroutine for writing kinetic law in MathML. 