### PR TITLE
Added toXML support for population maps

### DIFF
--- a/bng2/Perl2/BNGOutput.pm
+++ b/bng2/Perl2/BNGOutput.pm
@@ -592,31 +592,32 @@ sub toXML
 	$xml .= $string;
 
 	# Functions
-	$xml .= $indent . "<ListOfFunctions>\n";
-	$indent2 = "  " . $indent;
-	foreach my $param ( @{$plist->Array} )
+    $xml .= $indent . "<ListOfFunctions>\n";
+    $indent2 = "  " . $indent;
+    foreach my $param ( @{$plist->Array} )
     {
-		next unless ( $param->Type eq "Function" );
-		$xml .= $param->Ref->toXML( $plist, $indent2 );
-	}
-	$xml .= $indent . "</ListOfFunctions>\n";
+        next unless ( $param->Type eq "Function" );
+        $xml .= $param->Ref->toXML( $plist, $indent2 );
+    }
+    $xml .= $indent . "</ListOfFunctions>\n";
 
     # Energy Patterns
-	$xml .= $indent . "<ListOfEnergyPatterns>\n";
-	$indent2 = "  " . $indent;
-    my $epindex  = 1;
-	foreach my $eps ( @{$model->EnergyPatterns} )
-    {
-		$xml .= $eps->toXML( $plist, $indent2, $epindex );
-        ++$epindex;
-	}
-	$xml .= $indent . "</ListOfEnergyPatterns>\n";
+    if ( @{$model->EnergyPatterns} ) {
+        $xml .= $indent . "<ListOfEnergyPatterns>\n";
+        $indent2 = "  " . $indent;
+        my $epindex  = 1;
+        foreach my $eps ( @{$model->EnergyPatterns} )
+        {
+            $xml .= $eps->toXML( $plist, $indent2, $epindex );
+            ++$epindex;
+        }
+        $xml .= $indent . "</ListOfEnergyPatterns>\n";
+    }
 
-    # # Population Maps
-    # $xml .= $indent . "<ListOfPopulationMaps>\n";
-    # $indent2 = "  " . $indent;
-    # # pm stuff goes here
-    # $xml .= $indent . "</ListOfPopulationMaps>\n"
+    # Population Maps
+    if ( @{$model->PopulationList->List} ) {
+        $xml .= $model->PopulationList->toXML( $model, $plist, $indent );
+    }
 
 	# FOOTER
 	$xml .=  "  </model>\n"

--- a/bng2/Perl2/EnergyPattern.pm
+++ b/bng2/Perl2/EnergyPattern.pm
@@ -137,15 +137,13 @@ sub toMexString
 
 sub toXML
 {
-    # TODO: add comments
-
     my $epatt      = shift;
     my $plist      = (@_) ? shift : '';
     my $indent     = (@_) ? shift : '';
     my $index      = shift;
-    my $indent2    = "   " . $indent;
+    my $indent2    = "  " . $indent;
     my $id         = "EP" . $index;
-    my $pid = $id . "_P1";
+    my $pid        = $id . "_P1";
 
     my $string = $indent . '<EnergyPattern';
     $string .=  " id=\"" . $id . "\""; # id

--- a/bng2/Perl2/Population.pm
+++ b/bng2/Perl2/Population.pm
@@ -64,5 +64,35 @@ sub newPopulation
 };
 
 
+sub toXML
+{
+    my $pop     = shift;
+    my $plist   = shift;
+    my $indent  = (@_) ? shift : '';
+    my $indent2 = "  " . $indent;
+    my $indent3 = "  " . $indent2;
+    my $pmindex = shift;
+    my $pmid    = shift;
+    my $sid     = $pmid . "_SS1";
+    my $pid     = $pmid . "_PS1";
+    my $rid     = $pmid . "_RL1";
+
+    # get species (structured species)
+    my $popstring .= $indent2 . "<StructuredSpecies>\n";
+    $popstring .= $pop->SpeciesGraph->toXML( $indent3, "Species", $sid, "" );
+    $popstring .= $indent2 . "</StructuredSpecies>\n";
+
+    # get population count (population species)
+    $popstring .= $indent2 . "<PopulationSpecies>\n";
+    $popstring .= $pop->Population->toXML( $indent3, "Species", $pid, "" );
+    $popstring .= $indent2 . "</PopulationSpecies>\n";
+    
+    # get rate law
+    $popstring .= $pop->MappingRule->RateLaw->toXML( $indent2, $rid, $plist );
+
+    return $popstring;
+}
+
+
 
 1;

--- a/bng2/Perl2/PopulationList.pm
+++ b/bng2/Perl2/PopulationList.pm
@@ -89,4 +89,32 @@ sub getNumPopulations
     return scalar @{$pop_list->List};
 }
 
+
+
+sub toXML
+{
+    my $pl      = shift;
+    my $model   = shift;
+    my $plist   = (@_) ? shift : '';
+    my $indent  = (@_) ? shift : '';
+    my $indent2 = "  " . $indent;
+    my $pmindex = 1;
+    my $pmid    = "";
+
+	my $mapstring .= $indent . "<ListOfPopulationMaps>\n";
+	foreach my $popmap ( @{$model->PopulationList->List} )
+    {
+        $pmid = "PM" . $pmindex;
+        $mapstring .= $indent2 . "<PopulationMap id=\"" . $pmid . "\">\n";
+        $mapstring .= $popmap->toXML( $plist, $indent2, $pmindex, $pmid );
+        ++$pmindex;
+        $mapstring .= $indent2 . "</PopulationMap>\n";
+	}
+    $mapstring .= $indent . "</ListOfPopulationMaps>\n";
+
+    return $mapstring;
+}
+
+
+
 1;

--- a/bng2/Validate/DAT_validate/ANx.xml
+++ b/bng2/Validate/DAT_validate/ANx.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created by BioNetGen 2.7.1  -->
+<!-- Created by BioNetGen 2.7.0  -->
 <sbml xmlns="http://www.sbml.org/sbml/level3" level="3" version="1">
   <model id="ANx">
     <ListOfParameters>
@@ -1700,7 +1700,5 @@
         <Expression> kb*pOn(x) </Expression>
       </Function>
     </ListOfFunctions>
-    <ListOfEnergyPatterns>
-    </ListOfEnergyPatterns>
   </model>
 </sbml>

--- a/bng2/Validate/DAT_validate/simple_system.xml
+++ b/bng2/Validate/DAT_validate/simple_system.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created by BioNetGen 2.7.1  -->
+<!-- Created by BioNetGen 2.7.0  -->
 <sbml xmlns="http://www.sbml.org/sbml/level3" level="3" version="1">
   <model id="simple_system">
     <ListOfParameters>
@@ -356,7 +356,5 @@
     </ListOfObservables>
     <ListOfFunctions>
     </ListOfFunctions>
-    <ListOfEnergyPatterns>
-    </ListOfEnergyPatterns>
   </model>
 </sbml>

--- a/bng2/Validate/DAT_validate/test_compartment_XML.xml
+++ b/bng2/Validate/DAT_validate/test_compartment_XML.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created by BioNetGen 2.7.1  -->
+<!-- Created by BioNetGen 2.7.0  -->
 <sbml xmlns="http://www.sbml.org/sbml/level3" level="3" version="1">
   <model id="test_compartment_XML">
     <ListOfParameters>
@@ -161,7 +161,5 @@
     </ListOfObservables>
     <ListOfFunctions>
     </ListOfFunctions>
-    <ListOfEnergyPatterns>
-    </ListOfEnergyPatterns>
   </model>
 </sbml>

--- a/bng2/Validate/DAT_validate/test_setconc.xml
+++ b/bng2/Validate/DAT_validate/test_setconc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created by BioNetGen 2.7.1  -->
+<!-- Created by BioNetGen 2.7.0  -->
 <sbml xmlns="http://www.sbml.org/sbml/level3" level="3" version="1">
   <model id="test_setconc">
     <ListOfParameters>
@@ -201,7 +201,5 @@
     </ListOfObservables>
     <ListOfFunctions>
     </ListOfFunctions>
-    <ListOfEnergyPatterns>
-    </ListOfEnergyPatterns>
   </model>
 </sbml>


### PR DESCRIPTION
- Made appropriate changes to allow for writing of population maps to XML output, which in turn can be parsed by PyBioNetGen (resolves issue #237)
- Made minor formatting changes
- Updated appropriate XML files in the "DAT_validate" folder to match new changes