### PR TITLE
Allowed toXML support for Arrhenius rate law

### DIFF
--- a/bng2/Perl2/RateLaw.pm
+++ b/bng2/Perl2/RateLaw.pm
@@ -936,12 +936,6 @@ sub toXML
         return $rl->toXMLFunctionProduct($indent, $rr_id, $plist, $rrefs);
     }
 
-    if ( $rl->Type eq "Arrhenius" )
-    {   # not implemented since NFsim doesn't know how to use Arrhenius RateLaw!
-        send_warning("RateLaw::toXML does not yet support Arrhenius RateLaw!");
-        return "";
-    }   
-
     # handle other ratelaw types  
     # define ratelaw id
     my $id;


### PR DESCRIPTION
Stopped code from preventing XML output of Arrhenius rate laws, since they are necessary for PyBioNetGen's parsing and NFsim has its own method of handling them