### PR TITLE
ASinan Saglam/issue264

### DIFF
--- a/bng2/Perl2/BNGOutput.pm
+++ b/bng2/Perl2/BNGOutput.pm
@@ -1099,7 +1099,7 @@ sub writeSBML
         printf $SBML "      <initialAssignment symbol=\"S%i\">\n", $spec->Index;
         if (BNGUtils::isReal($spec->Concentration)) {
             print $SBML "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n";
-            printf $SBML "          <ci> %.8g </ci>\n", $spec->Concentration;
+            printf $SBML "          <cn> %.8g </cn>\n", $spec->Concentration;
             print $SBML "        </math>\n";
         } else {
             if ($spec->Concentration =~ /^_/) {

--- a/bng2/Perl2/BNGOutput.pm
+++ b/bng2/Perl2/BNGOutput.pm
@@ -1101,10 +1101,14 @@ sub writeSBML
             printf $SBML "          <ci> \"%.8g\" </ci>\n", $spec->Concentration;
             print $SBML "        </math>\n";
         } else {
-            print $SBML "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n";
-            printf $SBML "          <ci> %s </ci>\n", $spec->Concentration;
-            print $SBML "        </math>\n";
-            # printf $SBML $spec->Concentration->toMathMLString( $plist, "        " );
+            (my $param_lookup, my $err) = $plist->lookup($spec->Concentration);
+            if ( defined $param_lookup ) {
+                print $SBML $param_lookup->Expr->toMathMLString( $plist, "        " );
+            } else {
+                print $SBML "        <math xmlns=\"http://www.w3.org/1998/Math/MathML\">\n";
+                printf $SBML "          <ci> %s </ci>\n", $spec->Concentration;
+                print $SBML "        </math>\n";
+            }
         }
         # printf $SBML $spec->$conc->toMathMLString( $plist, "        " );
         print $SBML "      </initialAssignment>\n";


### PR DESCRIPTION
By default SBML exporting didn't export initial assignments block defined for SBML. This was mentioned in comments to be added in a future version (see [here](https://github.com/RuleWorld/bionetgen/blob/441dd92928359845cbd2eb69edfc8bc02eb97f58/bng2/Perl2/BNGOutput.pm#L1022)). Fixes #264 

Now, all species are exported in a SBML initial assignments block. Constant expressions are also exported in initial assignments block as long as they weren't a part of the original species block. 