### PR TITLE
Clean fix to catch species that refer to observables or functions

### DIFF
--- a/bng2/Perl2/SpeciesList.pm
+++ b/bng2/Perl2/SpeciesList.pm
@@ -240,6 +240,20 @@ sub readString
         # Read expression
         my $expr = Expression->new();
         if ( my $err = $expr->readString(\$string, $plist) ) {  return ('', $err);  }
+        # AS2023 - we need to check to ensure species does not refer
+        # to observables or functions block since they aren't evaluated
+        # during initialization and will cause `run_network`` to fail.
+        my $dependencies = $expr->getVariables($plist);
+        if ( exists $dependencies->{'Observable'}
+            or exists $dependencies->{'Function'}   )
+        {
+            my $spec_str = $sg->toString();
+            my $err = "Error while parsing species block, in species: $spec_str. ";
+            $err .= "Found species expressions that refer to observables or functions. ";
+            $err .= "This is not allowed, quitting!";
+            return ('', $err);
+        } 
+        # done checking dependencies
         if ( $expr->Type eq 'NUM' )
         {
             $conc = $expr->evaluate();


### PR DESCRIPTION
A simple fix that uses existing functionality that errors out when `BNG2.pl` reads a species expression that refers to observables or functions. This is done because while the resulting `.net` file and model is accurate, this won't work with `run_network` or other downstream tools. 

Now merging immediately until some discussion on whether we should fully error out or turn this into a warning. 