### PR TITLE
Fix issue #281: Add global flag to XML operator substitutions in Expr…

### DIFF
--- a/bng2/Perl2/Expression.pm
+++ b/bng2/Perl2/Expression.pm
@@ -1554,10 +1554,10 @@ sub toXML
     # the XML parser to work.<" with "&lt;", ">" with "&gt;", and
     #"&" with "&amp
     #print "before XML replacement: $string\n";
-    $string =~ s/</&lt\;/;
-    $string =~ s/>/&gt\;/;
-    $string =~ s/&&/and/;
-    $string =~ s/\|\|/or/;
+    $string =~ s/</&lt\;/g;
+    $string =~ s/>/&gt\;/g;
+    $string =~ s/&&/and/g;
+    $string =~ s/\|\|/or/g;
     #print "after XML replacement: $string\n";
     #END edit, msneddon
 

--- a/bng2/Validate/test_expression_xml_escaping.bngl
+++ b/bng2/Validate/test_expression_xml_escaping.bngl
@@ -1,0 +1,81 @@
+# Test case for issue #281: Expression.pm::toXML global substitution bug
+# This model tests that multiple occurrences of <, >, &&, and || operators
+# are properly escaped/replaced when serializing to XML.
+#
+# The bug: Expression.pm::toXML only replaces the FIRST occurrence of each
+# operator because the regex substitutions lack the /g (global) flag.
+#
+# Test expressions include:
+# - Multiple < comparisons: if((A<B)&&(B<C)&&(C<D), 1, 0)
+# - Multiple > comparisons: if((x>0)&&(y>0), 1, 0)
+# - Multiple && operators: combined with above
+# - Multiple || operators: if((x>0)||(y>0)||(z>0), 1, 0)
+# - Mixed operators: if((A<B)||(C>D), 1, 0)
+
+begin model
+
+begin parameters
+    k1   1.0
+    k2   2.0
+    A    1.0
+    B    2.0
+    C    3.0
+    D    4.0
+end parameters
+
+begin molecule types
+    X(s~0~1~2)
+    Y()
+end molecule types
+
+begin seed species
+    X(s~0)  100
+    Y()     50
+end seed species
+
+begin observables
+    Molecules X0 X(s~0)
+    Molecules X1 X(s~1)
+    Molecules X2 X(s~2)
+    Molecules Y_total Y()
+end observables
+
+begin functions
+    # Test multiple < operators with && operators
+    # After XML conversion, all < should become &lt; and all && should become 'and'
+    multi_less_than() = if((X0<X1)&&(X1<X2)&&(X2<Y_total), k1, 0)
+
+    # Test multiple > operators with && operators
+    # After XML conversion, all > should become &gt; and all && should become 'and'
+    multi_greater_than() = if((Y_total>X2)&&(X2>X1)&&(X1>X0), k2, 0)
+
+    # Test multiple || operators with > operators
+    # After XML conversion, all > should become &gt; and all || should become 'or'
+    multi_or() = if((X0>50)||(X1>50)||(X2>50), k1*2, 0)
+
+    # Test mixed < and > with ||
+    # All operators should be properly replaced
+    mixed_ops() = if((A<B)||(C>D), k2*2, 0)
+
+    # Test nested expressions with multiple operators
+    # This is a comprehensive test
+    nested_multi() = if((A<B)&&(B<C)&&((C<D)||(D>C)), k1+k2, k1)
+end functions
+
+begin reaction rules
+    # Use functions in reaction rules to ensure they get serialized to XML
+    X(s~0) -> X(s~1)  multi_less_than()
+    X(s~1) -> X(s~2)  multi_greater_than()
+    X(s~2) -> X(s~0)  multi_or()
+    Y() -> Y() + Y()  mixed_ops()
+end reaction rules
+
+end model
+
+## actions ##
+# Generate network and write XML to test Expression.pm::toXML
+generate_network({overwrite=>1})
+writeXML()
+
+# Run a short simulation to ensure the functions work correctly
+simulate({method=>"ode", t_end=>10, n_steps=>10})

--- a/bng2/Validate/test_expression_xml_escaping_verification.pl
+++ b/bng2/Validate/test_expression_xml_escaping_verification.pl
@@ -1,0 +1,114 @@
+#!/usr/bin/perl
+# Verification script for issue #281 fix
+# This script demonstrates the bug and verifies the fix
+
+use strict;
+use warnings;
+
+print "Testing regex substitution behavior for issue #281\n";
+print "=" x 60 . "\n\n";
+
+# Test strings with multiple occurrences
+my @test_cases = (
+    {
+        name => "Multiple < operators",
+        input => "if((A<B)&&(B<C)&&(C<D), 1, 0)",
+        expected_lt => 3,  # Should have 3 &lt;
+        expected_and => 2, # Should have 2 'and'
+    },
+    {
+        name => "Multiple > operators",
+        input => "if((x>0)&&(y>0)&&(z>0), 1, 0)",
+        expected_gt => 3,  # Should have 3 &gt;
+        expected_and => 2, # Should have 2 'and'
+    },
+    {
+        name => "Multiple || operators",
+        input => "if((x>0)||(y>0)||(z>0), 1, 0)",
+        expected_gt => 3,  # Should have 3 &gt;
+        expected_or => 2,  # Should have 2 'or'
+    },
+);
+
+foreach my $test (@test_cases) {
+    print "Test: $test->{name}\n";
+    print "Input: $test->{input}\n";
+
+    # Test WITHOUT /g (buggy version)
+    my $buggy = $test->{input};
+    $buggy =~ s/</&lt\;/;
+    $buggy =~ s/>/&gt\;/;
+    $buggy =~ s/&&/and/;
+    $buggy =~ s/\|\|/or/;
+
+    print "BUGGY (no /g): $buggy\n";
+
+    # Count replacements in buggy version
+    my $buggy_lt_count = () = $buggy =~ /&lt;/g;
+    my $buggy_gt_count = () = $buggy =~ /&gt;/g;
+    my $buggy_and_count = () = $buggy =~ /\band\b/g;
+    my $buggy_or_count = () = $buggy =~ /\bor\b/g;
+
+    # Test WITH /g (fixed version)
+    my $fixed = $test->{input};
+    $fixed =~ s/</&lt\;/g;
+    $fixed =~ s/>/&gt\;/g;
+    $fixed =~ s/&&/and/g;
+    $fixed =~ s/\|\|/or/g;
+
+    print "FIXED (with /g): $fixed\n";
+
+    # Count replacements in fixed version
+    my $fixed_lt_count = () = $fixed =~ /&lt;/g;
+    my $fixed_gt_count = () = $fixed =~ /&gt;/g;
+    my $fixed_and_count = () = $fixed =~ /\band\b/g;
+    my $fixed_or_count = () = $fixed =~ /\bor\b/g;
+
+    # Verify expectations
+    my $pass = 1;
+    if (exists $test->{expected_lt}) {
+        if ($buggy_lt_count != 1 && $buggy_lt_count != 0) {
+            print "  ERROR: Buggy version has unexpected &lt; count\n";
+            $pass = 0;
+        }
+        if ($fixed_lt_count != $test->{expected_lt}) {
+            print "  ERROR: Fixed version &lt; count ($fixed_lt_count) != expected ($test->{expected_lt})\n";
+            $pass = 0;
+        }
+    }
+    if (exists $test->{expected_gt}) {
+        if ($buggy_gt_count != 1 && $buggy_gt_count != 0) {
+            print "  ERROR: Buggy version has unexpected &gt; count\n";
+            $pass = 0;
+        }
+        if ($fixed_gt_count != $test->{expected_gt}) {
+            print "  ERROR: Fixed version &gt; count ($fixed_gt_count) != expected ($test->{expected_gt})\n";
+            $pass = 0;
+        }
+    }
+    if (exists $test->{expected_and}) {
+        if ($buggy_and_count != 1 && $buggy_and_count != 0) {
+            print "  ERROR: Buggy version has unexpected 'and' count\n";
+            $pass = 0;
+        }
+        if ($fixed_and_count != $test->{expected_and}) {
+            print "  ERROR: Fixed version 'and' count ($fixed_and_count) != expected ($test->{expected_and})\n";
+            $pass = 0;
+        }
+    }
+    if (exists $test->{expected_or}) {
+        if ($buggy_or_count != 1 && $buggy_or_count != 0) {
+            print "  ERROR: Buggy version has unexpected 'or' count\n";
+            $pass = 0;
+        }
+        if ($fixed_or_count != $test->{expected_or}) {
+            print "  ERROR: Fixed version 'or' count ($fixed_or_count) != expected ($test->{expected_or})\n";
+            $pass = 0;
+        }
+    }
+
+    print "  Result: " . ($pass ? "PASS" : "FAIL") . "\n";
+    print "\n";
+}
+
+print "Verification complete!\n";


### PR DESCRIPTION
…ession.pm

This commit fixes a bug where Expression.pm::toXML only replaced the first occurrence of <, >, &&, and || operators when serializing expressions to XML.

Changes:
- Added /g (global) flag to all four regex substitutions in Expression.pm:1557-1560
  * s/</&lt;/g  - properly escapes all < operators
  * s/>/&gt;/g  - properly escapes all > operators
  * s/&&/and/g - converts all && to 'and' for muParser compatibility
  * s/||/or/g  - converts all || to 'or' for muParser compatibility

Impact:
- Ensures valid XML output for complex expressions with multiple comparisons
- Fixes parser ambiguity/failures in downstream consumers of BioNetGen XML
- Improves correctness and robustness of XML serialization

Test coverage:
- Added test_expression_xml_escaping.bngl with comprehensive test cases covering multiple <, >, &&, and || operators in various combinations
- Added test_expression_xml_escaping_verification.pl to demonstrate the bug behavior and verify the fix

Fixes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)