### PR TITLE
Fix parameter-indexed tfun always evaluating to zero

### DIFF
--- a/bng2/Network3/src/network.cpp
+++ b/bng2/Network3/src/network.cpp
@@ -2369,9 +2369,8 @@ int init_network(Rxn_array* reactions, Elt_array* rates, Elt_array* species, Gro
 	/* Initialize function call counters */
 	network.n_deriv_calls = network.n_rate_calls = 0;
 
-	/* Initialize time pointer and tfun flag */
+	/* Initialize time pointer (tfun flag is set during read_functions_array) */
 	network.time_pointer = NULL;
-	network.has_tfuns = false;
 
 	return (0);
 }


### PR DESCRIPTION
## Summary

- `init_network()` was resetting `network.has_tfuns = false` after `read_functions_array()` had already set it to `true` during `.net` file parsing
- This caused `derivs_network()` to skip the tfun evaluation block entirely, so **parameter-indexed tfun values were never updated** from their initial value of 0
- Observable-indexed and time-indexed tfuns were unaffected because they also update through the ODE RHS via other code paths

## Reproducer

```bngl
begin model
begin parameters
  P 0.5
end parameters
begin molecule types
  X()
end molecule types
begin seed species
  X() 0
end seed species
begin observables
  Molecules Xtot X()
end observables
begin functions
  f() = tfun([0, 0.25, 0.5, 0.75, 1.0], [10, 20, 30, 40, 50], P)
end functions
begin reaction rules
  0 -> X() f()
  X() -> 0 1.0
end reaction rules
end model
generate_network({overwrite=>1})
simulate({method=>"ode", t_end=>10, n_steps=>10, print_functions=>1})
```

**Before fix:** `f` = 0 for all time steps, `Xtot` stays at 0
**After fix:** `f` = 30 (correct interpolation at P=0.5), `Xtot` converges to 30

## Fix

Remove the `network.has_tfuns = false;` line from `init_network()` (one line deletion in `network.cpp`). The flag is already correctly set during `read_functions_array()` and should not be reset afterward.

## Test plan

- [x] Verified parameter-indexed tfun produces correct values in simple test model
- [x] Verified observable-indexed tfun (`test_tfun_observable.bngl`) still works
- [x] Verified IPTG titration scan model with parameter-indexed tfun produces correct `exp_gfp_fig5a` values in `.scan` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)