### PR TITLE
docs(run_network): fix header comment typo 'river' -> 'driver'

### DIFF
--- a/bng2/Network3/src/run_network.cpp
+++ b/bng2/Network3/src/run_network.cpp
@@ -1,5 +1,5 @@
 /*
- *    run_network : river for network propagation routines,
+ *    run_network : driver for network propagation routines,
  *                    including ODE solvers and stochastic simulators.
  *
  *                  Copyright (C) 2006,2010,2012 by


### PR DESCRIPTION
Fixes #300. Single-character comment typo on line 2 of `bng2/Network3/src/run_network.cpp`.

```diff
- *    run_network : river for network propagation routines,
+ *    run_network : driver for network propagation routines,
```

Comment-only change.