### PR TITLE
Fix error message variable mismatch for .rab file open

### DIFF
--- a/bng2/Perl2/MacroBNGModel.pm
+++ b/bng2/Perl2/MacroBNGModel.pm
@@ -990,7 +990,7 @@ my (%m_spe,%s_spe,%rea_l,%rea_r,%rrea_l,%rrea_r,%dubl);
  $rabfile= "macr_${param_prefix}.rab";
  $netfile= "macr_${param_prefix}.net";
  open (RFILEnet, "<", $netfile) or die "Can't open $netfile: $!\n";
- open (WFILErab, ">", $rabfile) or die "Can't open $netfile: $!\n";
+ open (WFILErab, ">", $rabfile) or die "Can't open $rabfile: $!\n";
 
  while ( $line=<RFILEnet> ) {            # search-copy "begin molecule types"
    if ( $line =~ /begin molecule types/ ) {


### PR DESCRIPTION
### Summary
Fixes error message mismatch in MacroBNGModel.pm.

### Details
When opening `.rab` files, the `die` string incorrectly referenced `$netfile` instead of `$rabfile`. This caused misleading error messages when `.rab` file open operations failed.

### Location
File: bng2/Perl2/MacroBNGModel.pm, line 993

### Current Behavior
open (WFILErab, ">", $rabfile) or die "Can't open $netfile: $!\n";

### Expected Behavior
open (WFILErab, ">", $rabfile) or die "Can't open $rabfile: $!\n";

### Verification
Attempt to open a `.rab` file with invalid permissions.
Error message now correctly reports the `.rab` file instead of the `.net` file.

### Suggested Fix
Replaced `$netfile` with `$rabfile` in the `die` string.
