### PR TITLE
Fix unreachable "Fyn by SH2-bound Lyn" rule in FceRI Fyn demo models

### DIFF
--- a/bng2/Models2/FceriModels/fceri_fyn.bngl
+++ b/bng2/Models2/FceriModels/fceri_fyn.bngl
@@ -86,8 +86,8 @@ begin reaction rules
     Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~Y!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~pY) pLF
 
     # Transphosphorylation of Fyn by SH2-bound Lyn
-    Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~Y) -> \
-    Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~pY) pLFs
+    Lig(l!1,l!2).Lyn(U,SH2!3).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~Y) -> \
+    Lig(l!1,l!2).Lyn(U,SH2!3).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~pY) pLFs
 
     # Transphosphorylation of Syk by constitutive Lyn
     Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~Y!3).Rec(a!1,g~pY!4).Syk(tSH2!4,l~Y) -> \

--- a/bng2/Models2/FceriModels/fceri_fyn_lig.bngl
+++ b/bng2/Models2/FceriModels/fceri_fyn_lig.bngl
@@ -90,8 +90,8 @@ begin reaction rules
     Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~Y!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~pY) pLF
 
     # Transphosphorylation of Fyn by SH2-bound Lyn
-    Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~Y) -> \
-    Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~pY) pLFs
+    Lig(l!1,l!2).Lyn(U,SH2!3).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~Y) -> \
+    Lig(l!1,l!2).Lyn(U,SH2!3).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~pY) pLFs
 
     # Transphosphorylation of Syk by constitutive Lyn
     Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~Y!3).Rec(a!1,g~pY!4).Syk(tSH2!4,l~Y) -> \

--- a/bng2/Models2/FceriModels/fceri_fyn_trimer.bngl
+++ b/bng2/Models2/FceriModels/fceri_fyn_trimer.bngl
@@ -86,8 +86,8 @@ begin reaction rules
     Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~Y!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~pY) pLF
 
     # Transphosphorylation of Fyn by SH2-bound Lyn
-    Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~Y) -> \
-    Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~pY) pLFs
+    Lig(l!1,l!2).Lyn(U,SH2!3).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~Y) -> \
+    Lig(l!1,l!2).Lyn(U,SH2!3).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~pY) pLFs
 
     # Transphosphorylation of Syk by constitutive Lyn
     Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~Y!3).Rec(a!1,g~pY!4).Syk(tSH2!4,l~Y) -> \


### PR DESCRIPTION
## Summary

The three Fyn-containing FceRI demo models share a copy-paste error in the
reaction rule commented "Transphosphorylation of Fyn by SH2-bound Lyn", whose
rate constant in the BNGL file is `pLFs`. The rule binds Lyn's unique (U)
domain to a phosphorylated beta ITAM:

    Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~pY!3).Rec(a!1,b~pY!4).Fyn(SH2!4,a~Y) -> ...

That reactant pattern is unreachable. The U domain binds only unphosphorylated
beta (the constitutive Lyn-binding rule requires `b~Y`), and a U-bound beta is
never phosphorylated. The rule therefore expands to zero reactions, so Fyn ends
up phosphorylated only by constitutively bound Lyn. The pathway in which
SH2-recruited Lyn phosphorylates Fyn is silently missing.

Every other "by SH2-bound Lyn" rule in these models (for beta, gamma, the Syk
linker, and the Lyn activation loop) uses the correct form
`Lyn(U,SH2!3).Rec(...,b~pY!3)`, with the SH2 domain bound and the U domain free.
This PR changes the Fyn rule to match:

    -    Lig(l!1,l!2).Lyn(U!3,SH2).Rec(a!2,b~pY!3)...
    +    Lig(l!1,l!2).Lyn(U,SH2!3).Rec(a!2,b~pY!3)...

## Effect (BioNetGen 2.9.3, `generate_network`)

Number of `pLFs` reactions generated, before and after the fix:

| model | pLFs reactions | total reactions | species |
|---|---|---|---|
| `fceri_fyn.bngl` | 0 to 72 | 15256 to 15328 | 1281 (unchanged) |
| `fceri_fyn_lig.bngl` | 0 to 144 | 32776 to 32920 | 2506 (unchanged) |
| `fceri_fyn_trimer.bngl` | 0 to 3132 | 407308 to 410440 | 20881 (unchanged) |

Species counts are unchanged. The product species already existed via other
pathways, so the fix only adds the previously-missing reactions in which
SH2-recruited Lyn phosphorylates the Fyn activation loop.

## Files
- `bng2/Models2/FceriModels/fceri_fyn.bngl`
- `bng2/Models2/FceriModels/fceri_fyn_lig.bngl`
- `bng2/Models2/FceriModels/fceri_fyn_trimer.bngl`
