### PR TITLE
Fix loss of precision in MM rate law when Km is small and the enzyme is in excess

### DIFF
--- a/bng2/Network3/src/model/rateExpressions/rateMM.cpp
+++ b/bng2/Network3/src/model/rateExpressions/rateMM.cpp
@@ -53,8 +53,7 @@ double RateMM::getRate(vector<double> X){
 	// Rate calculation
 	double St = X[0];
 	double Et = X[1];
-	double b = St - Et - this->Km;
-	double S = 0.5*(b + sqrt(b*b + 4.0*St*this->Km));
+	double S = Util::mm_free_substrate(St, this->Km, Et);
 	double rate = this->kcat*Et*S/(this->Km + S);
 	return rate;
 }
@@ -72,9 +71,8 @@ double RateMM::get_dRate_dX(unsigned int which, vector<double> X){
 	// Rate calculation
 	double St = X[0];
 	double Et = X[1];
-	double b = St - Et - this->Km;
-	double sqrt_bb4ac = sqrt(b*b + 4.0*St*this->Km);
-	double S = 0.5*(b + sqrt_bb4ac);
+	double sqrt_bb4ac = 0.0;
+	double S = Util::mm_free_substrate(St, this->Km, Et, &sqrt_bb4ac);
 	//
 	double dRate = this->kcat/(this->Km + S);
 	//

--- a/bng2/Network3/src/network.cpp
+++ b/bng2/Network3/src/network.cpp
@@ -2455,7 +2455,7 @@ static double rxn_rate(Rxn* rxn, double* X, int discrete) {
 	int ig, /*i1, i2,*/n_denom;
 	int q;
 	double *param, x, xn, kn;
-	double St, Et, kcat, Km, S, b;
+	double St, Et, kcat, Km, S;
 
 	/* Don't calculate rate of null reactions */
 	if (!rxn)
@@ -2504,8 +2504,7 @@ static double rxn_rate(Rxn* rxn, double* X, int discrete) {
 		for (q = 1, Et = 0; q < rxn->n_reactants; ++q) {
 			Et += X[rxn->r_index[q]];
 		}
-		b = St - Km - Et;
-		S = 0.5 * (b + sqrt(b * b + 4.0 * St * Km));
+		S = Util::mm_free_substrate(St, Km, Et);
 		rate = rxn->stat_factor * kcat * Et * S / (Km + S);
 		break;
 
@@ -2657,7 +2656,7 @@ static double rxn_rate_scaled(Rxn* rxn, double* X, int discrete, double & iScali
 	int ig, /*i1, i2,*/n_denom;
 	int q, i;
 	double *param, x, xn, kn;
-	double St, Et, kcat, Km, S, b;
+	double St, Et, kcat, Km, S;
 	double scalingExp = 0.0;
 	double tempPop = 1.0;
 	double upperBound = 2 * poplevel;
@@ -2775,8 +2774,7 @@ static double rxn_rate_scaled(Rxn* rxn, double* X, int discrete, double & iScali
 			iScaling = 1.0;
 		}
 
-		b = (St - Km - Et) / iScaling;
-		S = 0.5 * (b + sqrt(b * b + 4.0 * St / iScaling * Km / iScaling));
+		S = Util::mm_free_substrate(St / iScaling, Km / iScaling, Et / iScaling);
 		rate = rxn->stat_factor * kcat * Et / iScaling * S / (Km / iScaling + S);
 		/* NOTE: the scaling method for MM equation is not 100% accurate, more nonlinearity brings more error */
 		break;

--- a/bng2/Network3/src/util/misc.cpp
+++ b/bng2/Network3/src/util/misc.cpp
@@ -20,6 +20,20 @@ void Util::remove_whitespace(string& s){
 	while (s.at(s.size()-1) == ' ' || s.at(s.size()-1) == '\t') s.erase(s.size()-1,1);
 }
 
+// Free (unbound) substrate concentration of the quasi-steady-state Michaelis-Menten
+// rate law: the non-negative root of S^2 - b*S - St*Km = 0, with b = St - Km - Et.
+// The textbook form 0.5*(b + sqrt(b*b + 4*St*Km)) cancels catastrophically when b < 0,
+// and rounds to exactly zero once 4*St*Km drops below about 1e-16*b*b, which silently
+// stops the reaction when Km is small and the enzyme is in excess. The roots multiply
+// to -St*Km, so the b < 0 case can be written with a sum of like-signed quantities.
+double Util::mm_free_substrate(double St, double Km, double Et, double* sqrt_disc){
+	double b = St - Km - Et;
+	double q = sqrt(b*b + 4.0*St*Km);
+	if (sqrt_disc) *sqrt_disc = q;
+	// q >= |b|, so q - b > 0 whenever b < 0
+	return (b >= 0.0) ? 0.5*(b + q) : 2.0*St*Km/(q - b);
+}
+
 double Util::Mratio(double a, double b, double z){
 	// Original Fortran code written by William Hlavacek (2018)
 	// Tranlsated to Python and then C++ by Leonard A. Harris (2019)

--- a/bng2/Network3/src/util/misc.hh
+++ b/bng2/Network3/src/util/misc.hh
@@ -26,6 +26,11 @@ namespace Util {
 	// Ratio of Kummer confluent hypergeometric functions M(a+1,b+1,z)/M(a,b,z)
 	// See https://en.wikipedia.org/wiki/Confluent_hypergeometric_function
 	double Mratio(double a, double b, double z);
+
+	// Free (unbound) substrate concentration of the quasi-steady-state Michaelis-Menten
+	// rate law, i.e., the non-negative root of S^2 - b*S - St*Km = 0, b = St - Km - Et.
+	// If sqrt_disc is non-NULL, sqrt(b*b + 4*St*Km) is returned through it.
+	double mm_free_substrate(double St, double Km, double Et, double* sqrt_disc = NULL);
 }
 
 #endif /* MISC_HH_ */

--- a/src/ast/Expression.cpp
+++ b/src/ast/Expression.cpp
@@ -206,7 +206,7 @@ double Expression::evaluate(const std::function<double(const std::string&)>& res
             return Vmax * S / (Km + S);
         }
         // MM(kcat, Km, St, Et) -> self-consistent Michaelis-Menten (BNG2 parity)
-        // Computes free substrate via quadratic: S = 0.5*(b + sqrt(b^2 + 4*St*Km))
+        // Computes free substrate as the non-negative root of S^2 - b*S - St*Km = 0,
         // where b = St - Km - Et, then rate = kcat * Et * S / (Km + S)
         if (text_ == "MM" || text_ == "mm") {
             if (children_.size() == 4) {
@@ -215,7 +215,11 @@ double Expression::evaluate(const std::function<double(const std::string&)>& res
                 const double St   = evalArg(2);  // total substrate
                 const double Et   = evalArg(3);  // total enzyme
                 const double b = St - Km - Et;
-                const double S = 0.5 * (b + std::sqrt(b * b + 4.0 * St * Km));
+                const double q = std::sqrt(b * b + 4.0 * St * Km);
+                // 0.5*(b + q) cancels catastrophically for b < 0 (enzyme in excess with
+                // small Km), losing all significant digits. The roots multiply to -St*Km,
+                // so that case is rewritten as a sum of like-signed quantities.
+                const double S = (b >= 0.0) ? 0.5 * (b + q) : 2.0 * St * Km / (q - b);
                 return kcat * Et * S / (Km + S);
             }
             // Fallback for 3-arg form (legacy): Vmax * S / (Km + S)

--- a/src/engine/OdeIntegrator.cpp
+++ b/src/engine/OdeIntegrator.cpp
@@ -482,7 +482,7 @@ void OdeIntegrator::compile() {
             if (paramNames.size() >= 2) {
                 // Sat(kcat, Km): rate = kcat * [S] / (Km + [S]) * [other reactants]
                 // MM(kcat, Km):  rate = self-consistent MM with quadratic for free substrate
-                //   St=reactant[0], Et=reactant[1], b=St-Et-Km, S=0.5*(b+sqrt(b^2+4*St*Km))
+                //   St=reactant[0], Et=reactant[1], S = non-negative root of S^2-b*S-St*Km=0, b=St-Km-Et
                 //   rate = kcat * Et * S / (Km + S)   (total rate, no further mass-action multiply)
                 // Hill(Vmax, Kh, n): rate = Vmax * [S]^n / (Kh^n + [S]^n) * [other reactants]
                 std::string kcat = paramNames[0];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -310,3 +310,14 @@ target_include_directories(test_ssc_writer PRIVATE
 )
 target_link_libraries(test_ssc_writer PRIVATE Catch2::Catch2WithMain Catch2::Catch2 bng_engine bng_ast bng_core antlr4_static)
 catch_discover_tests(test_ssc_writer)
+
+add_executable(test_michaelis_menten
+    test_michaelis_menten.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bng2/Network3/src/util/misc.cpp
+)
+target_include_directories(test_michaelis_menten PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_SOURCE_DIR}/../bng2/Network3/src
+)
+target_link_libraries(test_michaelis_menten PRIVATE Catch2::Catch2WithMain Catch2::Catch2 bng_ast)
+catch_discover_tests(test_michaelis_menten)

--- a/tests/test_michaelis_menten.cpp
+++ b/tests/test_michaelis_menten.cpp
@@ -1,0 +1,120 @@
+// Regression tests for the free substrate calculation of the Michaelis-Menten rate law.
+//
+// See https://github.com/RuleWorld/bionetgen/issues/323. The textbook form
+//
+//     b = St - Km - Et;  S = 0.5*(b + sqrt(b*b + 4*St*Km))
+//
+// cancels catastrophically when b < 0, i.e., when Km is small and the enzyme is in
+// excess, and rounds to exactly zero once 4*St*Km drops below about 1e-16*b*b, which
+// silently stops the reaction. Reference values below come from 60 digit arithmetic.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "ast/Expression.hpp"
+#include "util/misc.hh"  // bng2/Network3/src/util/misc.hh
+
+namespace {
+
+// Rate of a MM(kcat,Km) reaction as evaluated by the expression engine
+double mmRate(double kcat, double Km, double St, double Et) {
+    using bng::ast::Expression;
+    const Expression expr = Expression::function(
+        "MM", {Expression::number(kcat), Expression::number(Km), Expression::number(St),
+               Expression::number(Et)});
+    return expr.evaluate([](const std::string&) { return 0.0; });
+}
+
+struct SubstrateCase {
+    double St, Km, Et;
+    double S;  // exact free substrate
+};
+
+struct RateCase {
+    double kcat, Km, St, Et;
+    double rate;  // exact rate
+};
+
+// Loose enough to absorb differences in rounding between platforms, tight enough that
+// the old form fails every case with the enzyme in excess.
+constexpr double kTol = 1e-13;
+
+}  // namespace
+
+TEST_CASE("Michaelis-Menten free substrate", "[michaelis-menten]") {
+    SECTION("Matches high precision arithmetic") {
+        const std::vector<SubstrateCase> cases = {
+            // Enzyme in excess (b < 0): the regime that used to lose precision
+            {100.0, 1e-10, 200.0, 9.9999999999800004e-11},
+            {100.0, 1e-13, 200.0, 9.9999999999999803e-14},
+            {100.0, 1e-14, 200.0, 9.9999999999999980e-15},
+            {100.0, 1e-15, 200.0, 1.0000000000000001e-15},
+            {100.0, 1e-16, 200.0, 9.9999999999999998e-17},
+            {100.0, 1e-20, 200.0, 9.9999999999999995e-21},
+            {1e-3, 1e-9, 1e6, 1.0000000009999991e-18},
+            {1e6, 1e-8, 1e9, 1.0010010010010010e-11},
+            // Substrate in excess (b > 0) and ordinary parameter values
+            {200.0, 1e-14, 100.0, 100.00000000000001},
+            {10.0, 1.0, 5.0, 5.7416573867739414},
+            {2.0, 0.5, 7.0, 0.17617497767990628},
+        };
+        for (const SubstrateCase& c : cases) {
+            INFO("St=" << c.St << " Km=" << c.Km << " Et=" << c.Et);
+            REQUIRE_THAT(Util::mm_free_substrate(c.St, c.Km, c.Et),
+                         Catch::Matchers::WithinRel(c.S, kTol));
+        }
+    }
+
+    SECTION("Stays positive for positive Km with the enzyme in excess") {
+        // The old form returned exactly zero here, which stopped the reaction outright
+        for (double Km = 1e-8; Km > 1e-300; Km *= 1e-8) {
+            INFO("Km=" << Km);
+            REQUIRE(Util::mm_free_substrate(100.0, Km, 200.0) > 0.0);
+        }
+    }
+
+    SECTION("Reports the square root of the discriminant") {
+        const double St = 100.0, Km = 1e-14, Et = 200.0;
+        const double b = St - Km - Et;
+        double sqrt_disc = 0.0;
+        const double S = Util::mm_free_substrate(St, Km, Et, &sqrt_disc);
+        REQUIRE_THAT(sqrt_disc, Catch::Matchers::WithinRel(std::sqrt(b * b + 4.0 * St * Km), kTol));
+        // S is a root of S^2 - b*S - St*Km = 0, so 2*S - b is that same square root
+        REQUIRE_THAT(2.0 * S - b, Catch::Matchers::WithinRel(sqrt_disc, kTol));
+    }
+}
+
+TEST_CASE("Michaelis-Menten rate law", "[michaelis-menten]") {
+    SECTION("Matches high precision arithmetic") {
+        const std::vector<RateCase> cases = {
+            {1.0, 1e-10, 100.0, 200.0, 99.999999999900000},
+            {1.0, 1e-12, 100.0, 200.0, 99.999999999999000},
+            {1.0, 1e-13, 100.0, 200.0, 99.999999999999900},
+            {1.0, 1e-14, 100.0, 200.0, 99.999999999999990},
+            {1.0, 1e-15, 100.0, 200.0, 99.999999999999999},
+            {1.0, 1e-16, 100.0, 200.0, 100.00000000000000},
+            {1.0, 1e-20, 100.0, 200.0, 100.00000000000000},
+            {2.0, 1e-14, 200.0, 100.0, 199.99999999999998},
+            {1.0, 1.0, 10.0, 5.0, 4.2583426132260586},
+            {3.0, 0.5, 2.0, 7.0, 5.4714750669602812},
+            {1.0, 1e-9, 1e-3, 1e6, 9.9999999999999990e-4},
+        };
+        for (const RateCase& c : cases) {
+            INFO("kcat=" << c.kcat << " Km=" << c.Km << " St=" << c.St << " Et=" << c.Et);
+            REQUIRE_THAT(mmRate(c.kcat, c.Km, c.St, c.Et),
+                         Catch::Matchers::WithinRel(c.rate, kTol));
+        }
+    }
+
+    SECTION("Approaches kcat*min(St,Et) as Km goes to zero") {
+        for (double Km = 1e-8; Km > 1e-300; Km *= 1e-8) {
+            INFO("Km=" << Km);
+            REQUIRE_THAT(mmRate(1.0, Km, 100.0, 200.0), Catch::Matchers::WithinRel(100.0, 1e-7));
+            REQUIRE_THAT(mmRate(1.0, Km, 200.0, 100.0), Catch::Matchers::WithinRel(100.0, 1e-7));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #323.

## The problem

The free substrate concentration of the quasi-steady-state Michaelis-Menten rate law was computed as

```
b = St - Km - Et
S = 0.5 * (b + sqrt(b*b + 4.0*St*Km))
```

When `b` is negative and `4*St*Km` is small next to `b*b`, the square root is very close to `-b` and the sum cancels, so most of the significant digits are lost. Once `4*St*Km` falls below about `1e-16` of `b*b`, the sum rounds to exactly `0` and the reaction stops firing altogether. That happens whenever `Km` is small and the enzyme is in excess, which turns up on its own during parameter fitting, and it fails quietly: the reaction only slows down or goes dead.

## The fix

The two roots of `S^2 - b*S - St*Km = 0` multiply to `-St*Km`, so the non-negative root can equivalently be written `2*St*Km/(q - b)` with `q = sqrt(b*b + 4*St*Km)`. Selecting the branch on the sign of `b` makes both cases add like-signed quantities:

```
q = sqrt(b*b + 4.0*St*Km)
S = (b >= 0) ? 0.5*(b + q) : 2.0*St*Km/(q - b)
```

The `b >= 0` branch is the original expression, so results are bit-for-bit unchanged wherever the old code was accurate.

Sites changed:

* `bng2/Network3/src/network.cpp`, `MICHAELIS_MENTEN` in both `rxn_rate` and the population-scaled `rxn_rate_scaled`
* `bng2/Network3/src/model/rateExpressions/rateMM.cpp`, `RateMM::getRate` and `RateMM::get_dRate_dX`
* `src/ast/Expression.cpp`, the 4-argument `MM` form used by the C++ engine's ODE integrator

The Network3 copies now share one helper, `Util::mm_free_substrate` in `bng2/Network3/src/util/misc.{hh,cpp}`, rather than repeating the expression in four places. It optionally returns `sqrt(b*b + 4*St*Km)` through an out-parameter, which `get_dRate_dX` needs for the derivative.

## Verification

The repro from the issue (substrate 100, enzyme 200, `kcat` 1, so the exact rate tends to `kcat*St = 100` as `Km` goes to zero), initial rate read off the first ODE step:

| Km | run_network before | run_network after | exact |
|---|---|---|---|
| 1e-8  | 99.999830  | 99.999945 | 100.0 |
| 1e-10 | 100.000890 | 99.999908 | 100.0 |
| 1e-12 | 100.093176 | 99.999945 | 100.0 |
| 1e-13 | 99.737303  | 99.999945 | 100.0 |
| 1e-14 | 83.168239  | 99.999908 | 100.0 |
| 1e-15 | 0.000000   | 99.999945 | 100.0 |
| 1e-16 | 0.000000   | 99.999908 | 100.0 |

(The residual `1e-6` in the "after" column is the finite integration step, not the rate law; it is the same for every `Km`.)

Against 60 digit arithmetic over 280 parameter sets spanning `St`, `Et` in `[1e-3, 1e9]` and `Km` in `[0, 1e9]`: the old form returned exactly zero for a nonzero root in 62 of them and reached 100% relative error; the new form's worst relative error is `2.09e-16`, under 1 ulp. The one case above that, `2.11e-9` at `St = Et = 100`, `Km = 1e-14`, is cancellation in `b = St - Km - Et` itself, which no rewriting downstream of `b` can recover.

`bng2/Validate/validate_examples.pl` passes all 71 test models, including `test_MM`.

## Tests

`tests/test_michaelis_menten.cpp` is new. It checks `Util::mm_free_substrate` and the expression engine's `MM` against reference values from 60 digit arithmetic, that the free substrate stays positive for positive `Km` down to `1e-256` with the enzyme in excess, and that the rate approaches `kcat*min(St,Et)` as `Km` goes to zero. Every failing regime fails against the old expression; the ordinary-parameter cases pass against both, so they guard the unchanged branch.

## Not covered here

* NFsim carries the same expression in `MMRxnClass::update_a`, but it lives in its own repository, so it needs a separate one-line PR there.
* `Km` exactly `0` with `Et > St` gives `0/0` and returns NaN. That is unchanged by this PR and is a separate question, since the limit depends on the sign of `St - Et`.
