### PR TITLE
perf: reduce native C++ network-generation overhead

### DIFF
--- a/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
+++ b/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
@@ -230,9 +230,12 @@ calls nested in product construction. The FcERI profile likewise showed
 network generation as the relevant generation hotspot, while its full run was
 also dominated by the ODE solver.
 
-Measured alternatives were not retained. The last experiment used executable
-SHA-256 `de090c072b46654105f4a7b2bd4a2b62559b08f3cb5fd9ec41b8a14f942fd471`
-and compared the edge-lookup change directly with the retained candidate:
+Measured alternatives were not retained. The node-index edge-lookup experiment
+used executable SHA-256
+`de090c072b46654105f4a7b2bd4a2b62559b08f3cb5fd9ec41b8a14f942fd471`, and the
+serializer-key experiment used executable SHA-256
+`2f2bcd847bcb13ebb420fbf38fd386dfab78f5d9bace103cc6cd1eeb2dd2e930`. Both
+were compared directly with the retained candidate:
 
 | Experiment | Paired deltas by `SHP2`, `blbr`, `egfr_net`, `fceri_ji` | Decision |
 | --- | --- | --- |
@@ -241,6 +244,7 @@ and compared the edge-lookup change directly with the retained candidate:
 | Fingerprint-gated serialization | -1.982%, +9.640%, +3.199%, +0.407% | reject: broad regressions |
 | Fingerprint plus isomorphism precheck | +10.907%, +30.282%, +22.450%, +9.928% | reject: decisively slower |
 | Temporary node-index edge lookup (wall / CPU) | +0.205% / +0.217%, -0.600% / -1.554%, -0.928% / -1.006%, -0.964% / -1.003% | reject: SHP2 CPU regression; only 9/20 CPU wins |
+| Cached compartment-aware serializer keys (wall / CPU) | +0.066% / +0.061%, -0.071% / +0.118%, +0.529% / +0.509%, +0.748% / +0.719% | reject: EGFR and FcERI regressions; 7/20 and 4/20 CPU wins |
 
 The remaining profile-dominant CPU work is canonical labeling/Nauty and related
 graph/string operations inside rule expansion and species deduplication. ODE

--- a/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
+++ b/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
@@ -6,14 +6,19 @@ This series targets the native C++ network-generation path used by production
 models in `bng2/Models2`. It does not optimize a synthetic microbenchmark, alter
 the CLI, change generated-file formats, or add an external dependency.
 
-The retained optimization is the two-commit implementation in `533ac26b`
+The first retained optimization is the two-commit implementation in `533ac26b`
 (`perf: skip canonical labels for exact product duplicates`) and `92ca4c03`
 (`perf: preserve canonical product ordering in exact dedup fast path`). On the
-paired production matrix, median end-to-end wall-time changes ranged from
+paired production matrix, its median end-to-end wall-time changes ranged from
 -0.172% to -6.903%, and median CPU-time changes ranged from +0.081% to
 -7.288%. The small `blbr` case is close enough to the noise floor that it is
 reported as a workload limitation; the medium and large cases provide the
-material evidence for retaining the change.
+material evidence for retaining that change.
+
+The second retained optimization is `7ee2db11` (`perf: cache immutable
+reaction pattern metadata`). Against the first retained candidate, its median
+CPU-time change was negative on all four workloads, ranging from -0.856% to
+-2.317%; the detailed second matrix and its spread are recorded below.
 
 The branch also contains two correctness/build-enablement fixes and focused
 tests:
@@ -36,8 +41,8 @@ upstream/master at synchronization: 43ddf3afe165192a222fd13e4917a1902ffe3446
 origin/master at synchronization:   b00410628484f639efbf294f8a150f21c4e8bb29
 working branch:                      codex/portable-cpu-20260831
 baseline source:                     46da45c4
-retained performance source:         92ca4c03
-final source tree:                   e08a9bd2
+retained performance source:         92ca4c03, 7ee2db11
+final source tree:                   7ee2db11
 ```
 
 `git pull --ff-only origin master` was run before creating the dedicated
@@ -46,10 +51,10 @@ branch. At the candidate-source audit, the branch was six commits ahead of
 dirty files and explicitly listed untracked file were cleared at the user's
 request before this series began; the final tree is required to be clean.
 
-The final source tree includes the rejected exact-key experiment
-`70acc9e2` followed by `e08a9bd2`, which restores the retained implementation;
-the rejected experiment is documented below and is not present in the final
-source behavior.
+The final performance source includes the rejected exact-key experiment
+`70acc9e2` followed by `e08a9bd2`, which restores the retained implementation,
+and the accepted immutable pattern-metadata cache `7ee2db11`. The rejected
+experiment is documented below and is not present in the final source behavior.
 
 Input SHA-256 hashes:
 
@@ -124,11 +129,14 @@ python3 Benchmarks/portable_cpu_benchmark.py \
   --output /private/tmp/portable_cpu_exact_precheck_move_20.json
 ```
 
-The final Release executable at `build-codex/src/bng_cpp` has the same SHA-256
-as the candidate artifact used above. The baseline executable SHA-256 was
+The first retained Release executable had the same SHA-256 as the candidate
+artifact used above. The baseline executable SHA-256 was
 `ece7a09b247a2a8eb95dbaa26db7427aa0e5d0772f5b7b8097a6d36aa404399a`; the
-candidate executable SHA-256 was
+first retained candidate executable SHA-256 was
 `a59ed4dc4ff5becf347b95f1915c6ddaf60bc54d4bb84a0160ae60a737d2a9a2`.
+The final Release executable, including the metadata cache, is
+`build-codex/src/bng_cpp` with SHA-256
+`c4eeb05df99869d34364671089df598c7ecfc5f700c70e957297e968cb9b4d15`.
 CPU time and RSS use Python `resource.getrusage` because `/usr/bin/time -l`
 cannot read the required macOS counters in the sandbox.
 
@@ -149,6 +157,38 @@ for `fceri_ji`. Median maximum-RSS deltas were -0.146%, -0.610%, +0.379%,
 and +0.062% in the same workload order. The medium and large workloads
 therefore show repeatable CPU and wall-time reductions; `blbr` is retained
 only as a small correctness/noise check, not as the performance justification.
+
+The second retained optimization was measured against the first retained safe
+candidate (`a59ed4dc...`) with 40 paired repetitions per workload (320 raw
+records). The candidate executable was
+`c4eeb05df99869d34364671089df598c7ecfc5f700c70e957297e968cb9b4d15`. The raw
+result is `/private/tmp/portable_cpu_pattern_metadata_cache_40.json`.
+
+```sh
+python3 Benchmarks/portable_cpu_benchmark.py \
+  --executable-a /private/tmp/bng_cpp-candidate-exact-precheck-move \
+  --executable-b build-codex/src/bng_cpp \
+  --model bng2/Models2/blbr.bngl \
+  --model bng2/Models2/SHP2_base_model.bngl \
+  --model bng2/Models2/egfr_net.bngl \
+  --model bng2/Models2/fceri_ji.bngl \
+  --repetitions 40 --timeout 30 \
+  --output /private/tmp/portable_cpu_pattern_metadata_cache_40.json
+```
+
+| Workload | Wall retained -> cache (s) | Paired wall delta: median [IQR; min..max] | CPU retained -> cache (s) | Paired CPU delta: median [IQR; min..max] |
+| --- | ---: | ---: | ---: | ---: |
+| `blbr` | 0.023026 -> 0.022553 | -2.197% [-3.642..+0.358; -8.767..+4.164] | 0.022000 -> 0.021540 | -2.317% [-3.590..+0.368; -8.756..+4.781] |
+| `SHP2_base_model` | 0.151441 -> 0.150011 | -0.720% [-1.954..+0.503; -4.262..+2.893] | 0.149507 -> 0.148274 | -0.856% [-1.927..+0.131; -3.838..+2.036] |
+| `egfr_net` | 0.568566 -> 0.566068 | -0.997% [-1.621..+0.010; -4.814..+4.013] | 0.565503 -> 0.562712 | -1.014% [-1.633..-0.076; -4.098..+4.055] |
+| `fceri_ji` | 0.637187 -> 0.631220 | -1.108% [-1.396..-0.436; -5.827..+0.483] | 0.633409 -> 0.626914 | -1.116% [-1.435..-0.593; -5.985..+0.042] |
+
+Paired wall/CPU wins in this second run were 29/40 and 29/40 for `blbr`,
+27/40 and 29/40 for `SHP2`, 29/40 and 31/40 for `egfr_net`, and 38/40 and
+39/40 for `fceri_ji`. Median maximum-RSS deltas were -0.438%, +0.989%,
+0.000%, and +0.372%, respectively. All four CPU medians improved; the
+medium workload's IQR crosses zero slightly, so this records the consistent
+direction and artifact identity without claiming every individual pair wins.
 
 ## Mechanism changed
 
@@ -171,16 +211,29 @@ pre-canonical exact key into insertion timed out on `Motivating_example_cBNGL`
 because canonical labeling can change serializer order; its safety-gated
 variant was noise-level or slower and was not retained.
 
+`src/ast/ReactionRule.hpp` and `src/ast/ReactionRule.cpp` add a per-rule cache
+of the immutable `PatternInfo` descriptions for reactant and product graphs.
+The cache is built during `initialize()` and reused by embedding searches,
+reaction construction, and delete-molecule handling, eliminating repeated
+metadata allocations without changing graph ownership, match ordering, or
+operation data. The out-of-line destructor and move operations keep the
+opaque cache type portable across translation units.
+
 The focused regression in `tests/ast/test_SpeciesList.cpp` covers two species
 with identical structure but different molecule compartments, exact duplicate
 reuse, and the resulting list size. The empty-graph test covers the
-canonicalization guard needed by the validated build.
+canonicalization guard needed by the validated build. The existing
+`tests/ast/test_network_generator.cpp` path also reinitializes and moves a
+`ReactionRule` into a model before checking generated species/reaction counts,
+covering the cached rule metadata's lifecycle.
 
 ## Correctness evidence
 
-For all 20 repetitions of all four workloads, the candidate and baseline
-output-hash maps were identical. The resulting deterministic artifacts had
-these stable hashes:
+For all 20 repetitions of all four workloads in the first retained comparison,
+the candidate and baseline output-hash maps were identical. For all 40
+repetitions in the metadata-cache comparison, the cache candidate and the
+retained executable also had identical output-hash maps, sizes, and network
+counts. The resulting deterministic artifacts had these stable hashes:
 
 ```text
 blbr.net                         f983ce459044a975daa8ddf68b74cba694117cc56f03047dfadee4c904795bc2
@@ -257,13 +310,13 @@ were compared directly with the retained candidate:
 | Safety-gated exact-key handoff (canonical graphs only) | +0.625% / +0.513%, +0.078% / -0.031%, +0.548% / +0.637%, -0.188% / -0.193% | reject: noise-level/slower; no material matrix win |
 | Fingerprint lookup before canonical labeling | -0.535% / -0.541%, +3.241% / +4.009%, +0.133% / +0.195%, -0.460% / -0.366% | reject: `blbr` CPU regression; no broad win |
 
-The remaining profile-dominant CPU work is canonical labeling/Nauty and related
-graph/string operations inside rule expansion and species deduplication. ODE
-integration is another dominant cost for ODE-heavy models such as FcERI. A
-further material gain in those areas would require a broader canonicalization
-and deduplication data-structure redesign, parallel/GPU execution, or a
-different-language implementation; those are outside this portable,
-semantics-preserving scope.
+The remaining profile-dominant CPU work after both retained changes is
+canonical labeling/Nauty and related graph/string operations inside rule
+expansion and species deduplication. ODE integration is another dominant cost
+for ODE-heavy models such as FcERI. A further material gain in those areas
+would require a broader canonicalization and deduplication data-structure
+redesign, parallel/GPU execution, or a different-language implementation;
+those are outside this portable, semantics-preserving scope.
 
 ## Validation commands and status
 
@@ -272,6 +325,7 @@ Targeted tests and the full Release CTest suite were run on the candidate:
 ```sh
 build-codex/tests/test_SpeciesList
 build-codex/tests/test_pattern_graph
+build-codex/tests/test_network_generator
 ctest --test-dir build-codex --output-on-failure --parallel 4
 ```
 

--- a/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
+++ b/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
@@ -1,0 +1,276 @@
+# Portable CPU performance report
+
+## Scope and result
+
+This series targets the native C++ network-generation path used by production
+models in `bng2/Models2`. It does not optimize a synthetic microbenchmark, alter
+the CLI, change generated-file formats, or add an external dependency.
+
+The retained optimization is `533ac26b` (`perf: skip canonical labels for
+exact product duplicates`). On the paired production matrix, the median
+end-to-end wall-time change was negative for every workload, with median CPU
+time reductions of 2.189% to 4.177%. The small `blbr` case is close enough to
+the noise floor that it is reported as a workload limitation; the medium and
+large cases provide the material evidence for retaining the change.
+
+The branch also contains two correctness/build-enablement fixes and focused
+tests:
+
+* `77c8bd8c` constrains legacy `BNGcore` inequality overloads to BNGcore types,
+  fixing an Apple Clang/libc++ ADL ambiguity.
+* `46da45c4` defines empty pattern-graph canonicalization and adds its test.
+* `5291159d` tests that compartment-aware species remain distinct while exact
+  duplicates still deduplicate.
+
+## Repository and source provenance
+
+The repository was synchronized before benchmarking:
+
+```text
+fork:     https://github.com/akutuva21/bionetgen.git
+upstream: https://github.com/RuleWorld/bionetgen.git
+upstream default discovered with git ls-remote --symref: master
+upstream/master at synchronization: 43ddf3afe165192a222fd13e4917a1902ffe3446
+origin/master at synchronization:   b00410628484f639efbf294f8a150f21c4e8bb29
+working branch:                      codex/portable-cpu-20260831
+baseline source:                     46da45c4
+candidate source:                    533ac26b
+```
+
+`git pull --ff-only origin master` was run before creating the dedicated
+branch. At the final source audit, the branch was four commits ahead of
+`origin/master` and seven commits ahead of `upstream/master`. The previously
+dirty files and explicitly listed untracked file were cleared at the user's
+request before this series began; the final tree is required to be clean.
+
+Input SHA-256 hashes:
+
+| Model | SHA-256 |
+| --- | --- |
+| `bng2/Models2/blbr.bngl` | `c3290588efecbd3be2e57d883e851d6b28edd0c39eed43a491aa5c20533b6e96` |
+| `bng2/Models2/SHP2_base_model.bngl` | `790d51dc260f9b3da7cd214ea6290998c81ed4ab4bd2f2e0dd8f16c49eb8182a` |
+| `bng2/Models2/egfr_net.bngl` | `843e07954d5dfb1acc99e294a2d7518b41f4813992567edc2c47794cec10a1da` |
+| `bng2/Models2/fceri_ji.bngl` | `fa31fe7375510bb3e05f2335719a71abc1a22ada75be3eb5a8d5a0c80f29227e` |
+
+## Hardware and build configuration
+
+```text
+OS:             macOS 26.6.2, Darwin 25.6.0, arm64
+Hardware:       Mac17,9; 15 logical CPUs; 24 GiB RAM
+C++ compiler:   /usr/bin/clang++ Apple clang 21.0.0 (clang-2100.1.1.101)
+CMake:          4.4.3
+Python:         3.9.6
+Perl:           5.34.1
+Build type:     Release
+Architectures:  arm64
+Release flags:  -O3 -DNDEBUG
+Dependencies:   Catch2 v3.4.0, ANTLR4 4.13.1, SUNDIALS v7.6.0
+SUNDIALS index: 64-bit; static dependency builds
+```
+
+Release configuration and build:
+
+```sh
+cmake -S . -B build-codex \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DBUILD_TESTING=ON
+cmake --build build-codex --parallel 4
+```
+
+## Workloads and benchmark protocol
+
+The model actions exercise native parsing, network generation, and—where the
+model defines them—deterministic ODE/steady-state execution:
+
+| Workload | Role | Model action | Generated network |
+| --- | --- | --- | --- |
+| `blbr` | small/noise check | network generation | 20 species, 118 reactions |
+| `SHP2_base_model` | medium | network generation, ODE 1000/100, steady state | 149 species, 1082 reactions |
+| `egfr_net` | large | network generation, ODE 40/50 | 356 species, 3749 reactions |
+| `fceri_ji` | large | network generation, ODE 600/10 | 354 species, 3680 reactions |
+
+No stochastic or SSA action is present in this matrix, so there was no RNG
+seed or stochastic event signature to compare. This is a limitation of this
+target selection, not a claim of stochastic validation.
+
+The committed runner is
+`Benchmarks/portable_cpu_benchmark.py`. It starts a fresh worker process and
+fresh run directory for every executable invocation, copies the pinned model,
+alternates baseline/candidate order on each pair, and records raw JSON for
+wall time, user/system CPU time, maximum RSS, output sizes and hashes, network
+species/reaction counts, data-row counts, command lines, and input/executable
+hashes. Twenty paired repetitions were used per model:
+
+```sh
+python3 Benchmarks/portable_cpu_benchmark.py \
+  --executable-a /private/tmp/bng_cpp-baseline-46da45c4 \
+  --executable-b /private/tmp/bng_cpp-candidate-no-second-final \
+  --model bng2/Models2/blbr.bngl \
+  --model bng2/Models2/SHP2_base_model.bngl \
+  --model bng2/Models2/egfr_net.bngl \
+  --model bng2/Models2/fceri_ji.bngl \
+  --repetitions 20 --timeout 30 \
+  --output /private/tmp/portable_cpu_final_committed_20.json
+```
+
+The baseline executable SHA-256 was
+`ece7a09b247a2a8eb95dbaa26db7427aa0e5d0772f5b7b8097a6d36aa404399a`; the
+candidate executable SHA-256 was
+`b48ee3bf7cc5ab2f221f74817c5c5d6dcd1cb74e4a8b4233cb0caed2502aa997`.
+CPU time and RSS use Python `resource.getrusage` because `/usr/bin/time -l`
+cannot read the required macOS counters in the sandbox.
+
+The percentage is `100 * (candidate - baseline) / baseline`; negative means
+the candidate is faster. The table reports independent medians and paired
+median deltas. IQR and min/max are the paired percentage spread.
+
+| Workload | Outputs: bytes; data rows | Wall baseline -> candidate (s) | Paired wall delta: median [IQR; min..max] | CPU baseline -> candidate (s) | Paired CPU delta: median [IQR; min..max] |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `blbr` | 5,112; N/A | 0.023465 -> 0.022803 | -2.485% [-5.388..+0.010; -7.318..+15.641] | 0.022277 -> 0.021774 | -2.189% [-5.080..+0.094; -7.933..+14.746] |
+| `SHP2_base_model` | 343,261; 202 | 0.164372 -> 0.154803 | -5.534% [-6.830..-2.895; -11.842..+6.140] | 0.162745 -> 0.153166 | -5.430% [-6.779..-3.369; -11.258..+4.601] |
+| `egfr_net` | 549,606; 102 | 0.581370 -> 0.554530 | -4.172% [-5.728..-3.129; -12.009..-0.153] | 0.578498 -> 0.552434 | -4.177% [-5.720..-3.162; -11.333..-0.144] |
+| `fceri_ji` | 233,656; 22 | 0.658142 -> 0.636508 | -3.624% [-4.526..-2.227; -12.055..+9.517] | 0.656252 -> 0.634688 | -3.618% [-4.516..-2.305; -11.838..-1.313] |
+
+Paired wall/CPU wins were respectively 15/20 and 15/20 for `blbr`, 18/20
+and 18/20 for `SHP2`, 20/20 and 20/20 for `egfr_net`, and 19/20 and 20/20
+for `fceri_ji`. Median maximum-RSS deltas were -0.581%, -0.188%, +0.581%,
+and +0.186% in the same workload order. The large workloads therefore show
+repeatable CPU and wall-time reductions; `blbr` is retained only as a small
+correctness/noise check, not as the performance justification.
+
+## Mechanism changed
+
+`src/ast/SpeciesList.cpp` now computes the compartment-aware exact string key
+before canonical labeling and checks the exact-key index first. Product graphs
+that are exact duplicates consequently return without paying for canonical
+labeling. Canonical labeling remains in the fallback path. For species with a
+species-level compartment, the deduplication string is recomputed after
+canonicalization because serialization can depend on canonical node ordering;
+unscoped species retain the pre-label exact key and existing canonical-label
+and structural-fingerprint fallbacks.
+
+`src/ast/ReactionRule.cpp` now inserts a product into `SpeciesList` before
+requesting its canonical label and obtains the label from the stored graph.
+This removes the eager product-graph label call on duplicate products in the
+synthesis and product-building paths while preserving the labels used for
+reaction sorting and output.
+
+The focused regression in `tests/ast/test_SpeciesList.cpp` covers two species
+with identical structure but different molecule compartments, exact duplicate
+reuse, and the resulting list size. The empty-graph test covers the
+canonicalization guard needed by the validated build.
+
+## Correctness evidence
+
+For all 20 repetitions of all four workloads, the candidate and baseline
+output-hash maps were identical. The resulting deterministic artifacts had
+these stable hashes:
+
+```text
+blbr.net                         f983ce459044a975daa8ddf68b74cba694117cc56f03047dfadee4c904795bc2
+SHP2_base_model.net              6620f31870265eff428152ed30940c5ca2e282205f1b0d438cce61ea7f7148f3
+SHP2_base_model.cdat             05528472a0c0c48d88929651b6b37123d9e2c6c0b109a8bd9d5a512c222da95b
+SHP2_base_model.gdat             542fd2ba1e4117b809b38fb8d0c836c26a827d8e4a6ea9edcd3f94038068f957
+egfr_net.net                     84dce91d99d292092ec89878103d2f1ff6819d9f08415937728e733cd0a4eb71
+egfr_net.cdat                    352544d406b91466d30494e59f5df228ae983b002221a6a53fd000bbd49c048b
+egfr_net.gdat                    4ea6425ae6e3e9a7ebcf7336d5454e6fc12fe78cdadf8c6d8fb3da85ca7de439
+fceri_ji.net                     f0cc7a523f6b8376bda9de1f3306fea9722b682559d33f05fd4dd2fd6107ad73
+fceri_ji.cdat                    b2caf3891093c858af935a420a5331512ee9b11a1383fa9f4d701915ba125a3b
+fceri_ji.gdat                    a3bb8268b0de2294aec732dddefc93def96a500a334f0a4d756e7e894effa5bc
+```
+
+Independent BNG2 reference generation used the checked-out Perl implementation
+(`bng2/BNG2.pl`, reported version 2.9.3, SHA-256
+`cf5fd82d3df9b84835d29234bd32268b87eaa985dd221bd5d39aadef744795f4`). The
+reference command was `perl bng2/BNG2.pl <copied-model>.bngl`, followed by the
+repository validators:
+
+```sh
+perl bng2/Validate/compare_species.pl -n <candidate.net> <reference.net>
+perl bng2/Validate/compare_rxn.pl <candidate.net> <reference.net>
+```
+
+Results were:
+
+| Workload | Candidate network | Independent BNG2 network | Species comparison | Reaction comparison |
+| --- | ---: | ---: | --- | --- |
+| `blbr` | 20 / 118 | 20 / 92 | pass | fail: pre-existing reaction-count mismatch |
+| `SHP2_base_model` | 149 / 1082 | 149 / 1032 | pass | fail: pre-existing reaction-count mismatch |
+| `egfr_net` | 356 / 3749 | 356 / 3749 | pass | pass |
+| `fceri_ji` | 354 / 3680 | 354 / 3680 | pass | pass |
+
+Counts are species/reactions. The two small/reference mismatches were present
+in the baseline C++ behavior before this optimization and are not introduced
+by the candidate; candidate-vs-baseline artifacts remain byte-identical. The
+repository `compare_rxn.pl` also emits a pre-existing missing-argument warning
+and prints a misleading `0 versus 0` count in its failure message; the counts
+above were independently parsed from both `.net` files.
+
+## Profiles and rejected alternatives
+
+The baseline macOS `sample` profile for an EGFR network-generation run
+captured 5 seconds and 5,648 samples. The dominant stack was
+`ActionDispatch::execute` (3,295), `NetworkGenerator::generate` (3,015),
+`NetworkGenerator::generateNative` (3,013), and
+`ReactionRule::expandRule` (1,175). `SpeciesList::add`, canonical labeling,
+`find_canonical_order`, and BNG2-string serialization were visible below that
+stack. A final-candidate profile captured 5 seconds and 3,615 samples, with
+the same dominant stack: `NetworkGenerator::generateNative` (2,980),
+`ReactionRule::expandRule` (1,104), `SpeciesList::add` (173), and canonical
+label calls nested in the species-add path. The FcERI profile likewise showed
+network generation as the relevant generation hotspot, while its full run was
+also dominated by the ODE solver.
+
+Measured alternatives were not retained:
+
+| Experiment | Paired wall-time deltas by `SHP2`, `blbr`, `egfr_net`, `fceri_ji` | Decision |
+| --- | --- | --- |
+| `std::map<Node*, int>` -> unordered map in canonicalization | +1.009%, -1.365%, +0.232%, -0.281% | reject: inconsistent and slower on two larger cases |
+| Exact-first without the compartment-safe follow-up | -4.611%, +5.299%, +1.444%, -1.441% | reject: regressions on `blbr` and EGFR |
+| Fingerprint-gated serialization | -1.982%, +9.640%, +3.199%, +0.407% | reject: broad regressions |
+| Fingerprint plus isomorphism precheck | +10.907%, +30.282%, +22.450%, +9.928% | reject: decisively slower |
+
+The remaining profile-dominant CPU work is canonical labeling/Nauty and related
+graph/string operations inside rule expansion and species deduplication. ODE
+integration is another dominant cost for ODE-heavy models such as FcERI. A
+further material gain in those areas would require a broader canonicalization
+and deduplication data-structure redesign, parallel/GPU execution, or a
+different-language implementation; those are outside this portable,
+semantics-preserving scope.
+
+## Validation commands and status
+
+Targeted tests and the full Release CTest suite were run on the candidate:
+
+```sh
+build-codex/tests/test_SpeciesList
+build-codex/tests/test_pattern_graph
+ctest --test-dir build-codex --output-on-failure --parallel 4
+```
+
+The targeted tests passed repeatedly, and the full suite passed 80/80. The
+ASan/UBSan build used the same source and pinned local dependency trees:
+
+```sh
+cmake -S . -B /private/tmp/bng-build-asan \
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 -DBUILD_TESTING=ON \
+  -DCMAKE_C_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer' \
+  -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer' \
+  -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address,undefined' \
+  -DCMAKE_SHARED_LINKER_FLAGS='-fsanitize=address,undefined' \
+  -DFETCHCONTENT_SOURCE_DIR_CATCH2="$PWD/build/_deps/catch2-src" \
+  -DFETCHCONTENT_SOURCE_DIR_ANTLR4_RUNTIME="$PWD/build/_deps/antlr4_runtime-src" \
+  -DFETCHCONTENT_SOURCE_DIR_SUNDIALS="$PWD/build/_deps/sundials-src"
+cmake --build /private/tmp/bng-build-asan --parallel 4
+ctest --test-dir /private/tmp/bng-build-asan --output-on-failure --parallel 4
+```
+
+The sanitizer suite passed 80/80, and separate ASan/UBSan production runs of
+all four models exited successfully without sanitizer diagnostics. GitHub CI
+must still be checked against the exact pushed final branch SHA; that external
+result is intentionally not inferred from local test results.

--- a/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
+++ b/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
@@ -47,12 +47,12 @@ final source tree:                   7ee2db11
 
 `git pull --ff-only origin master` was run before creating the dedicated
 branch. At the pre-cache candidate-source audit, the branch was six commits
-ahead of `origin/master` and nine commits ahead of `upstream/master`. At the
-final audit, `HEAD` and `origin/codex/portable-cpu-20260831` were both
-`d7002abe33f665d0ccccafc81e5acec411065f73`; the branch was 14 commits ahead
-of `origin/master` and 17 commits ahead of `upstream/master`. The previously
-dirty files and explicitly listed untracked file were cleared at the user's
-request before this series began; the final tree is required to be clean.
+ahead of `origin/master` and nine commits ahead of `upstream/master`. A final
+local/remote audit was performed after the source and documentation commits;
+the delivered branch ref, divergence, and CI/PR query results are reported in
+the delivery summary. The previously dirty files and explicitly listed
+untracked file were cleared at the user's request before this series began;
+the final tree is required to be clean.
 
 The final performance source includes the rejected exact-key experiment
 `70acc9e2` followed by `e08a9bd2`, which restores the retained implementation,

--- a/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
+++ b/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
@@ -10,8 +10,8 @@ The retained optimization is the two-commit implementation in `533ac26b`
 (`perf: skip canonical labels for exact product duplicates`) and `92ca4c03`
 (`perf: preserve canonical product ordering in exact dedup fast path`). On the
 paired production matrix, median end-to-end wall-time changes ranged from
--0.172% to -6.903%, and median CPU-time changes ranged from -0.215% to
--6.875%. The small `blbr` case is close enough to the noise floor that it is
+-0.172% to -6.903%, and median CPU-time changes ranged from +0.081% to
+-7.288%. The small `blbr` case is close enough to the noise floor that it is
 reported as a workload limitation; the medium and large cases provide the
 material evidence for retaining the change.
 
@@ -36,7 +36,8 @@ upstream/master at synchronization: 43ddf3afe165192a222fd13e4917a1902ffe3446
 origin/master at synchronization:   b00410628484f639efbf294f8a150f21c4e8bb29
 working branch:                      codex/portable-cpu-20260831
 baseline source:                     46da45c4
-candidate source:                    92ca4c03
+retained performance source:         92ca4c03
+final source tree:                   e08a9bd2
 ```
 
 `git pull --ff-only origin master` was run before creating the dedicated
@@ -44,6 +45,11 @@ branch. At the candidate-source audit, the branch was six commits ahead of
 `origin/master` and nine commits ahead of `upstream/master`. The previously
 dirty files and explicitly listed untracked file were cleared at the user's
 request before this series began; the final tree is required to be clean.
+
+The final source tree includes the rejected exact-key experiment
+`70acc9e2` followed by `e08a9bd2`, which restores the retained implementation;
+the rejected experiment is documented below and is not present in the final
+source behavior.
 
 Input SHA-256 hashes:
 
@@ -118,7 +124,8 @@ python3 Benchmarks/portable_cpu_benchmark.py \
   --output /private/tmp/portable_cpu_exact_precheck_move_20.json
 ```
 
-The baseline executable SHA-256 was
+The final Release executable at `build-codex/src/bng_cpp` has the same SHA-256
+as the candidate artifact used above. The baseline executable SHA-256 was
 `ece7a09b247a2a8eb95dbaa26db7427aa0e5d0772f5b7b8097a6d36aa404399a`; the
 candidate executable SHA-256 was
 `a59ed4dc4ff5becf347b95f1915c6ddaf60bc54d4bb84a0160ae60a737d2a9a2`.
@@ -131,10 +138,10 @@ median deltas. IQR and min/max are the paired percentage spread.
 
 | Workload | Outputs: bytes; data rows | Wall baseline -> candidate (s) | Paired wall delta: median [IQR; min..max] | CPU baseline -> candidate (s) | Paired CPU delta: median [IQR; min..max] |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `blbr` | 5,112; N/A | 0.024501 -> 0.024358 | -0.172% [-0.832..+0.522; -6.923..+1.550] | 0.023071 -> 0.022978 | -0.215% [-1.369..+0.641; -7.116..+2.146] |
-| `SHP2_base_model` | 343,261; 202 | 0.164564 -> 0.153212 | -6.903% [-7.483..-6.295; -8.662..-5.533] | 0.162525 -> 0.151263 | -6.875% [-7.499..-6.347; -8.610..-5.610] |
-| `egfr_net` | 549,606; 102 | 0.582642 -> 0.566102 | -2.985% [-3.502..-2.451; -5.289..-1.055] | 0.579735 -> 0.563011 | -2.957% [-3.724..-2.491; -5.374..-1.218] |
-| `fceri_ji` | 233,656; 22 | 0.665730 -> 0.638934 | -3.938% [-4.338..-3.769; -5.251..-2.903] | 0.662634 -> 0.636178 | -3.944% [-4.311..-3.755; -5.227..-2.907] |
+| `blbr` | 5,112; N/A | 0.024501 -> 0.024358 | -0.172% [-0.832..+0.522; -6.923..+1.550] | 0.021025 -> 0.020930 | +0.081% [-0.961..+0.636; -7.255..+1.262] |
+| `SHP2_base_model` | 343,261; 202 | 0.164564 -> 0.153212 | -6.903% [-7.483..-6.295; -8.662..-5.533] | 0.158193 -> 0.147044 | -7.288% [-7.528..-6.808; -8.215..-5.269] |
+| `egfr_net` | 549,606; 102 | 0.582642 -> 0.566102 | -2.985% [-3.502..-2.451; -5.289..-1.055] | 0.570982 -> 0.554018 | -3.210% [-3.531..-2.240; -5.084..-1.687] |
+| `fceri_ji` | 233,656; 22 | 0.665730 -> 0.638934 | -3.938% [-4.338..-3.769; -5.251..-2.903] | 0.653576 -> 0.627741 | -3.956% [-4.284..-3.753; -5.625..-3.032] |
 
 Paired wall/CPU wins were respectively 11/20 and 11/20 for `blbr`, 20/20
 and 20/20 for `SHP2`, 20/20 and 20/20 for `egfr_net`, and 20/20 and 20/20
@@ -159,9 +166,10 @@ probes the exact key, and returns the existing cached label immediately for an
 exact duplicate. Only an exact-key miss canonicalizes the owned graph before
 insertion, preserving the original canonical product ordering for non-duplicate
 products. Labels are then read from the stored graph, preserving reaction
-sorting and output. This ordering is important: an earlier prototype that
-passed an uncanonicalized copy into `SpeciesList` timed out on
-`Motivating_example_cBNGL` and was not retained.
+sorting and output. This ordering is important: a follow-up that carried a
+pre-canonical exact key into insertion timed out on `Motivating_example_cBNGL`
+because canonical labeling can change serializer order; its safety-gated
+variant was noise-level or slower and was not retained.
 
 The focused regression in `tests/ast/test_SpeciesList.cpp` covers two species
 with identical structure but different molecule compartments, exact duplicate
@@ -245,6 +253,9 @@ were compared directly with the retained candidate:
 | Fingerprint plus isomorphism precheck | +10.907%, +30.282%, +22.450%, +9.928% | reject: decisively slower |
 | Temporary node-index edge lookup (wall / CPU) | +0.205% / +0.217%, -0.600% / -1.554%, -0.928% / -1.006%, -0.964% / -1.003% | reject: SHP2 CPU regression; only 9/20 CPU wins |
 | Cached compartment-aware serializer keys (wall / CPU) | +0.066% / +0.061%, -0.071% / +0.118%, +0.529% / +0.509%, +0.748% / +0.719% | reject: EGFR and FcERI regressions; 7/20 and 4/20 CPU wins |
+| Exact-key handoff after product canonicalization | -0.885% / -0.836%, -5.938% / -6.848%, -4.592% / -4.395%, -1.648% / -1.667% | reject: timed out on `Motivating_example_cBNGL` in the 41-model harness |
+| Safety-gated exact-key handoff (canonical graphs only) | +0.625% / +0.513%, +0.078% / -0.031%, +0.548% / +0.637%, -0.188% / -0.193% | reject: noise-level/slower; no material matrix win |
+| Fingerprint lookup before canonical labeling | -0.535% / -0.541%, +3.241% / +4.009%, +0.133% / +0.195%, -0.460% / -0.366% | reject: `blbr` CPU regression; no broad win |
 
 The remaining profile-dominant CPU work is canonical labeling/Nauty and related
 graph/string operations inside rule expansion and species deduplication. ODE
@@ -284,18 +295,25 @@ ctest --test-dir /private/tmp/bng-build-asan --output-on-failure --parallel 4
 ```
 
 The sanitizer suite passed 80/80, and separate ASan/UBSan production runs of
-all four models exited successfully without sanitizer diagnostics. GitHub CI
-must still be checked against the exact pushed final branch SHA; the branch
-workflows trigger only on `master` pushes or pull requests, so a branch push
-alone does not create a run.
+all four models exited successfully without sanitizer diagnostics. No GitHub
+Actions run can be created for this branch under the current workflow triggers:
+they run on `master` pushes or pull requests, and the user explicitly
+requested no RuleWorld pull request and no fork-default-branch push.
 
 The repository script `scripts/validate_cpp_against_perl.sh` was also run over
-all 41 available reference models for both executables using a temporary
-macOS-compatible `timeout` shim (GNU `timeout` is not installed here). The
-baseline and final candidate each produced 34 passes and 7 failures, with the
-same failure set: the SHP2/blbr reaction-count mismatches, missing NFsim for
+all 41 available reference models for the final source using a temporary
+macOS-compatible `timeout` shim (GNU `timeout` is not installed here). It
+produced 34 passes and 7 failures, with the same failure set documented above:
+the SHP2/blbr reaction-count mismatches, missing NFsim for
 `isingspin_localfcn`, missing companion `.net` for `michment_cont`, unsupported
 XML `readFile` in two SBML cases, and the missing `f_correct` parameter in
-`test_time`. Thus the corrected optimization did not widen the repository
-validation failure footprint. These are reported rather than silently treated
-as green.
+`test_time`. The previously passing `Motivating_example_cBNGL` also passed;
+the rejected exact-key experiment had timed out there. These are reported
+rather than silently treated as green.
+
+No GitHub Actions run was created for the final branch SHA. The checked-in
+workflows trigger on `master` pushes or pull requests, while the user
+explicitly directed that no pull request be opened against `RuleWorld` and no
+fork default-branch push be made. The final branch was pushed only to the
+fork; local Release, independent-reference, full-harness, and ASan/UBSan
+evidence above are the available validation for this no-PR delivery.

--- a/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
+++ b/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
@@ -6,12 +6,14 @@ This series targets the native C++ network-generation path used by production
 models in `bng2/Models2`. It does not optimize a synthetic microbenchmark, alter
 the CLI, change generated-file formats, or add an external dependency.
 
-The retained optimization is `533ac26b` (`perf: skip canonical labels for
-exact product duplicates`). On the paired production matrix, the median
-end-to-end wall-time change was negative for every workload, with median CPU
-time reductions of 2.189% to 4.177%. The small `blbr` case is close enough to
-the noise floor that it is reported as a workload limitation; the medium and
-large cases provide the material evidence for retaining the change.
+The retained optimization is the two-commit implementation in `533ac26b`
+(`perf: skip canonical labels for exact product duplicates`) and `92ca4c03`
+(`perf: preserve canonical product ordering in exact dedup fast path`). On the
+paired production matrix, median end-to-end wall-time changes ranged from
+-0.172% to -6.903%, and median CPU-time changes ranged from -0.215% to
+-6.875%. The small `blbr` case is close enough to the noise floor that it is
+reported as a workload limitation; the medium and large cases provide the
+material evidence for retaining the change.
 
 The branch also contains two correctness/build-enablement fixes and focused
 tests:
@@ -34,12 +36,12 @@ upstream/master at synchronization: 43ddf3afe165192a222fd13e4917a1902ffe3446
 origin/master at synchronization:   b00410628484f639efbf294f8a150f21c4e8bb29
 working branch:                      codex/portable-cpu-20260831
 baseline source:                     46da45c4
-candidate source:                    533ac26b
+candidate source:                    92ca4c03
 ```
 
 `git pull --ff-only origin master` was run before creating the dedicated
-branch. At the final source audit, the branch was four commits ahead of
-`origin/master` and seven commits ahead of `upstream/master`. The previously
+branch. At the candidate-source audit, the branch was six commits ahead of
+`origin/master` and nine commits ahead of `upstream/master`. The previously
 dirty files and explicitly listed untracked file were cleared at the user's
 request before this series began; the final tree is required to be clean.
 
@@ -107,19 +109,19 @@ hashes. Twenty paired repetitions were used per model:
 ```sh
 python3 Benchmarks/portable_cpu_benchmark.py \
   --executable-a /private/tmp/bng_cpp-baseline-46da45c4 \
-  --executable-b /private/tmp/bng_cpp-candidate-no-second-final \
+  --executable-b /private/tmp/bng_cpp-candidate-exact-precheck-move \
   --model bng2/Models2/blbr.bngl \
   --model bng2/Models2/SHP2_base_model.bngl \
   --model bng2/Models2/egfr_net.bngl \
   --model bng2/Models2/fceri_ji.bngl \
   --repetitions 20 --timeout 30 \
-  --output /private/tmp/portable_cpu_final_committed_20.json
+  --output /private/tmp/portable_cpu_exact_precheck_move_20.json
 ```
 
 The baseline executable SHA-256 was
 `ece7a09b247a2a8eb95dbaa26db7427aa0e5d0772f5b7b8097a6d36aa404399a`; the
 candidate executable SHA-256 was
-`b48ee3bf7cc5ab2f221f74817c5c5d6dcd1cb74e4a8b4233cb0caed2502aa997`.
+`a59ed4dc4ff5becf347b95f1915c6ddaf60bc54d4bb84a0160ae60a737d2a9a2`.
 CPU time and RSS use Python `resource.getrusage` because `/usr/bin/time -l`
 cannot read the required macOS counters in the sandbox.
 
@@ -129,34 +131,37 @@ median deltas. IQR and min/max are the paired percentage spread.
 
 | Workload | Outputs: bytes; data rows | Wall baseline -> candidate (s) | Paired wall delta: median [IQR; min..max] | CPU baseline -> candidate (s) | Paired CPU delta: median [IQR; min..max] |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| `blbr` | 5,112; N/A | 0.023465 -> 0.022803 | -2.485% [-5.388..+0.010; -7.318..+15.641] | 0.022277 -> 0.021774 | -2.189% [-5.080..+0.094; -7.933..+14.746] |
-| `SHP2_base_model` | 343,261; 202 | 0.164372 -> 0.154803 | -5.534% [-6.830..-2.895; -11.842..+6.140] | 0.162745 -> 0.153166 | -5.430% [-6.779..-3.369; -11.258..+4.601] |
-| `egfr_net` | 549,606; 102 | 0.581370 -> 0.554530 | -4.172% [-5.728..-3.129; -12.009..-0.153] | 0.578498 -> 0.552434 | -4.177% [-5.720..-3.162; -11.333..-0.144] |
-| `fceri_ji` | 233,656; 22 | 0.658142 -> 0.636508 | -3.624% [-4.526..-2.227; -12.055..+9.517] | 0.656252 -> 0.634688 | -3.618% [-4.516..-2.305; -11.838..-1.313] |
+| `blbr` | 5,112; N/A | 0.024501 -> 0.024358 | -0.172% [-0.832..+0.522; -6.923..+1.550] | 0.023071 -> 0.022978 | -0.215% [-1.369..+0.641; -7.116..+2.146] |
+| `SHP2_base_model` | 343,261; 202 | 0.164564 -> 0.153212 | -6.903% [-7.483..-6.295; -8.662..-5.533] | 0.162525 -> 0.151263 | -6.875% [-7.499..-6.347; -8.610..-5.610] |
+| `egfr_net` | 549,606; 102 | 0.582642 -> 0.566102 | -2.985% [-3.502..-2.451; -5.289..-1.055] | 0.579735 -> 0.563011 | -2.957% [-3.724..-2.491; -5.374..-1.218] |
+| `fceri_ji` | 233,656; 22 | 0.665730 -> 0.638934 | -3.938% [-4.338..-3.769; -5.251..-2.903] | 0.662634 -> 0.636178 | -3.944% [-4.311..-3.755; -5.227..-2.907] |
 
-Paired wall/CPU wins were respectively 15/20 and 15/20 for `blbr`, 18/20
-and 18/20 for `SHP2`, 20/20 and 20/20 for `egfr_net`, and 19/20 and 20/20
-for `fceri_ji`. Median maximum-RSS deltas were -0.581%, -0.188%, +0.581%,
-and +0.186% in the same workload order. The large workloads therefore show
-repeatable CPU and wall-time reductions; `blbr` is retained only as a small
-correctness/noise check, not as the performance justification.
+Paired wall/CPU wins were respectively 11/20 and 11/20 for `blbr`, 20/20
+and 20/20 for `SHP2`, 20/20 and 20/20 for `egfr_net`, and 20/20 and 20/20
+for `fceri_ji`. Median maximum-RSS deltas were -0.146%, -0.610%, +0.379%,
+and +0.062% in the same workload order. The medium and large workloads
+therefore show repeatable CPU and wall-time reductions; `blbr` is retained
+only as a small correctness/noise check, not as the performance justification.
 
 ## Mechanism changed
 
-`src/ast/SpeciesList.cpp` now computes the compartment-aware exact string key
-before canonical labeling and checks the exact-key index first. Product graphs
-that are exact duplicates consequently return without paying for canonical
-labeling. Canonical labeling remains in the fallback path. For species with a
-species-level compartment, the deduplication string is recomputed after
-canonicalization because serialization can depend on canonical node ordering;
-unscoped species retain the pre-label exact key and existing canonical-label
-and structural-fingerprint fallbacks.
+`src/ast/SpeciesList.cpp` now exposes an exact-key lookup that checks the
+compartment-aware string index without canonicalizing the graph. The existing
+`add` path also checks that exact key before canonical labeling. Canonical
+labeling remains in the fallback path. For species with a species-level
+compartment, the deduplication string is recomputed after canonicalization
+because serialization can depend on canonical node ordering; unscoped species
+retain the pre-label exact key and existing canonical-label and
+structural-fingerprint fallbacks.
 
-`src/ast/ReactionRule.cpp` now inserts a product into `SpeciesList` before
-requesting its canonical label and obtains the label from the stored graph.
-This removes the eager product-graph label call on duplicate products in the
-synthesis and product-building paths while preserving the labels used for
-reaction sorting and output.
+`src/ast/ReactionRule.cpp` moves each product graph into a temporary `Species`,
+probes the exact key, and returns the existing cached label immediately for an
+exact duplicate. Only an exact-key miss canonicalizes the owned graph before
+insertion, preserving the original canonical product ordering for non-duplicate
+products. Labels are then read from the stored graph, preserving reaction
+sorting and output. This ordering is important: an earlier prototype that
+passed an uncanonicalized copy into `SpeciesList` timed out on
+`Motivating_example_cBNGL` and was not retained.
 
 The focused regression in `tests/ast/test_SpeciesList.cpp` covers two species
 with identical structure but different molecule compartments, exact duplicate
@@ -211,16 +216,17 @@ above were independently parsed from both `.net` files.
 
 ## Profiles and rejected alternatives
 
-The baseline macOS `sample` profile for an EGFR network-generation run
+The baseline macOS `sample` profile for repeated EGFR network-generation runs
 captured 5 seconds and 5,648 samples. The dominant stack was
 `ActionDispatch::execute` (3,295), `NetworkGenerator::generate` (3,015),
 `NetworkGenerator::generateNative` (3,013), and
 `ReactionRule::expandRule` (1,175). `SpeciesList::add`, canonical labeling,
 `find_canonical_order`, and BNG2-string serialization were visible below that
-stack. A final-candidate profile captured 5 seconds and 3,615 samples, with
-the same dominant stack: `NetworkGenerator::generateNative` (2,980),
-`ReactionRule::expandRule` (1,104), `SpeciesList::add` (173), and canonical
-label calls nested in the species-add path. The FcERI profile likewise showed
+stack. A direct final-candidate EGFR profile captured the same stack during
+the run: `ActionDispatch::execute` (248 samples),
+`NetworkGenerator::generateNative` (223), `ReactionRule::expandRule` (81),
+`SpeciesList::add` (at least 9 samples in its top path), and canonical-label
+calls nested in product construction. The FcERI profile likewise showed
 network generation as the relevant generation hotspot, while its full run was
 also dominated by the ODE solver.
 
@@ -272,5 +278,17 @@ ctest --test-dir /private/tmp/bng-build-asan --output-on-failure --parallel 4
 
 The sanitizer suite passed 80/80, and separate ASan/UBSan production runs of
 all four models exited successfully without sanitizer diagnostics. GitHub CI
-must still be checked against the exact pushed final branch SHA; that external
-result is intentionally not inferred from local test results.
+must still be checked against the exact pushed final branch SHA; the branch
+workflows trigger only on `master` pushes or pull requests, so a branch push
+alone does not create a run.
+
+The repository script `scripts/validate_cpp_against_perl.sh` was also run over
+all 41 available reference models for both executables using a temporary
+macOS-compatible `timeout` shim (GNU `timeout` is not installed here). The
+baseline and final candidate each produced 34 passes and 7 failures, with the
+same failure set: the SHP2/blbr reaction-count mismatches, missing NFsim for
+`isingspin_localfcn`, missing companion `.net` for `michment_cont`, unsupported
+XML `readFile` in two SBML cases, and the missing `f_correct` parameter in
+`test_time`. Thus the corrected optimization did not widen the repository
+validation failure footprint. These are reported rather than silently treated
+as green.

--- a/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
+++ b/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
@@ -230,14 +230,17 @@ calls nested in product construction. The FcERI profile likewise showed
 network generation as the relevant generation hotspot, while its full run was
 also dominated by the ODE solver.
 
-Measured alternatives were not retained:
+Measured alternatives were not retained. The last experiment used executable
+SHA-256 `de090c072b46654105f4a7b2bd4a2b62559b08f3cb5fd9ec41b8a14f942fd471`
+and compared the edge-lookup change directly with the retained candidate:
 
-| Experiment | Paired wall-time deltas by `SHP2`, `blbr`, `egfr_net`, `fceri_ji` | Decision |
+| Experiment | Paired deltas by `SHP2`, `blbr`, `egfr_net`, `fceri_ji` | Decision |
 | --- | --- | --- |
 | `std::map<Node*, int>` -> unordered map in canonicalization | +1.009%, -1.365%, +0.232%, -0.281% | reject: inconsistent and slower on two larger cases |
 | Exact-first without the compartment-safe follow-up | -4.611%, +5.299%, +1.444%, -1.441% | reject: regressions on `blbr` and EGFR |
 | Fingerprint-gated serialization | -1.982%, +9.640%, +3.199%, +0.407% | reject: broad regressions |
 | Fingerprint plus isomorphism precheck | +10.907%, +30.282%, +22.450%, +9.928% | reject: decisively slower |
+| Temporary node-index edge lookup (wall / CPU) | +0.205% / +0.217%, -0.600% / -1.554%, -0.928% / -1.006%, -0.964% / -1.003% | reject: SHP2 CPU regression; only 9/20 CPU wins |
 
 The remaining profile-dominant CPU work is canonical labeling/Nauty and related
 graph/string operations inside rule expansion and species deduplication. ODE

--- a/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
+++ b/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
@@ -46,8 +46,11 @@ final source tree:                   7ee2db11
 ```
 
 `git pull --ff-only origin master` was run before creating the dedicated
-branch. At the candidate-source audit, the branch was six commits ahead of
-`origin/master` and nine commits ahead of `upstream/master`. The previously
+branch. At the pre-cache candidate-source audit, the branch was six commits
+ahead of `origin/master` and nine commits ahead of `upstream/master`. At the
+final audit, `HEAD` and `origin/codex/portable-cpu-20260831` were both
+`d7002abe33f665d0ccccafc81e5acec411065f73`; the branch was 14 commits ahead
+of `origin/master` and 17 commits ahead of `upstream/master`. The previously
 dirty files and explicitly listed untracked file were cleared at the user's
 request before this series began; the final tree is required to be clean.
 

--- a/Benchmarks/portable_cpu_benchmark.py
+++ b/Benchmarks/portable_cpu_benchmark.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Paired CPU benchmark runner for native BioNetGen workloads.
+
+Each executable invocation runs in a fresh directory and child process. Pairs
+alternate which executable runs first so scheduler and thermal drift are not
+confounded with the candidate. The JSON output is intentionally raw enough to
+support independent statistical summaries.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - Windows has no resource module
+    resource = None
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def output_files(run_dir, model_name):
+    return sorted(
+        path for path in pathlib.Path(run_dir).iterdir()
+        if path.name != model_name and path.is_file()
+    )
+
+
+def net_counts(path):
+    counts = {"species_count": None, "reaction_count": None}
+    if not path.exists():
+        return counts
+
+    section = None
+    for raw_line in path.read_text(errors="replace").splitlines():
+        line = raw_line.strip()
+        lower = line.lower()
+        if lower.startswith("begin "):
+            section = lower[6:].strip()
+            continue
+        if lower == "end" or lower.startswith("end "):
+            section = None
+            continue
+        if section == "species" and line and not line.startswith("#"):
+            counts["species_count"] = (counts["species_count"] or 0) + 1
+        elif section in ("reactions", "reaction rules") and line and not line.startswith("#"):
+            counts["reaction_count"] = (counts["reaction_count"] or 0) + 1
+    return counts
+
+
+def data_row_count(path):
+    if not path.exists():
+        return 0
+    return sum(
+        1 for raw_line in path.read_text(errors="replace").splitlines()
+        if raw_line.strip() and not raw_line.lstrip().startswith("#")
+    )
+
+
+def run_worker(args):
+    run_dir = pathlib.Path(args.run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    model_name = pathlib.Path(args.model).name
+    model_path = run_dir / model_name
+    shutil.copy2(args.model, model_path)
+
+    before = resource.getrusage(resource.RUSAGE_CHILDREN) if resource else None
+    started = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            [args.executable, str(model_path)],
+            cwd=run_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=args.timeout,
+        )
+        returncode = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+    except subprocess.TimeoutExpired as exc:
+        returncode = 124
+        stdout = exc.stdout or ""
+        stderr = (exc.stderr or "") + "\nbenchmark timeout\n"
+
+    elapsed = time.perf_counter() - started
+    after = resource.getrusage(resource.RUSAGE_CHILDREN) if resource else None
+    files = output_files(run_dir, model_name)
+    net_path = run_dir / (pathlib.Path(model_name).stem + ".net")
+    hashes = {path.name: sha256(path) for path in files}
+    sizes = {path.name: path.stat().st_size for path in files}
+    counts = net_counts(net_path)
+    counts["output_row_count"] = sum(
+        data_row_count(path) for path in files if path.suffix in (".gdat", ".cdat")
+    ) or None
+
+    result = {
+        "returncode": returncode,
+        "wall_seconds": elapsed,
+        "cpu_user_seconds": (after.ru_utime - before.ru_utime) if resource else None,
+        "cpu_system_seconds": (after.ru_stime - before.ru_stime) if resource else None,
+        "max_rss": after.ru_maxrss if resource else None,
+        "output_sizes": sizes,
+        "output_hashes": hashes,
+        "output_bytes": sum(sizes.values()),
+        "counts": counts,
+        "stdout": stdout,
+        "stderr": stderr,
+        "command": [args.executable, str(model_path)],
+    }
+    print(json.dumps(result), flush=True)
+    return returncode
+
+
+def run_one(script, executable, model, run_dir, timeout):
+    completed = subprocess.run(
+        [sys.executable, script, "--worker", "--executable", executable,
+         "--model", model, "--run-dir", str(run_dir), "--timeout", str(timeout)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if not completed.stdout.strip():
+        raise RuntimeError("worker failed: " + completed.stderr)
+    return json.loads(completed.stdout.strip().splitlines()[-1])
+
+
+def run_matrix(args):
+    executable_a = os.path.abspath(args.executable_a)
+    executable_b = os.path.abspath(args.executable_b)
+    models = [os.path.abspath(model) for model in args.models]
+    results = []
+
+    with tempfile.TemporaryDirectory(prefix="bng-paired-") as root:
+        root_path = pathlib.Path(root)
+        pair_index = 0
+        for model in models:
+            for repetition in range(1, args.repetitions + 1):
+                first_a = (pair_index % 2) == 0
+                order = [("baseline", executable_a), ("candidate", executable_b)]
+                if not first_a:
+                    order.reverse()
+
+                pair = {}
+                for label, executable in order:
+                    run_dir = root_path / pathlib.Path(model).stem / str(repetition) / label
+                    data = run_one(args.script, executable, model, run_dir, args.timeout)
+                    data.update({
+                        "label": label,
+                        "model": model,
+                        "model_sha256": sha256(model),
+                        "repetition": repetition,
+                        "pair_index": pair_index,
+                    })
+                    pair[label] = data
+                    results.append(data)
+
+                if pair["baseline"]["returncode"] != 0 or pair["candidate"]["returncode"] != 0:
+                    raise RuntimeError(json.dumps(pair, indent=2))
+                pair_index += 1
+
+    payload = {
+        "executable_a": executable_a,
+        "executable_b": executable_b,
+        "executable_a_sha256": sha256(executable_a),
+        "executable_b_sha256": sha256(executable_b),
+        "repetitions": args.repetitions,
+        "timeout_seconds": args.timeout,
+        "results": results,
+    }
+    pathlib.Path(args.output).write_text(json.dumps(payload, indent=2) + "\n")
+    print(json.dumps({"output": args.output, "records": len(results)}, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--worker", action="store_true")
+    parser.add_argument("--executable")
+    parser.add_argument("--model", action="append", dest="models")
+    parser.add_argument("--executable-a")
+    parser.add_argument("--executable-b")
+    parser.add_argument("--repetitions", type=int, default=20)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument("--output", default="portable_cpu_benchmark.json")
+    parser.add_argument("--run-dir")
+    parser.add_argument("--script", default=os.path.abspath(__file__))
+    args = parser.parse_args()
+
+    if args.worker:
+        if not args.run_dir or not args.executable or not args.models:
+            parser.error("worker mode requires --executable, --model, and --run-dir")
+        args.model = args.models[0]
+        return run_worker(args)
+
+    if not args.executable_a or not args.executable_b or not args.models:
+        parser.error("matrix mode requires --executable-a, --executable-b, and --model")
+    run_matrix(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/parsers/ContactMap/createGraph.py
+++ b/parsers/ContactMap/createGraph.py
@@ -186,6 +186,14 @@ def createSubGraph(reactantList,
                 edgeArray.append(clusterName)
     return edgeArray           
 
+def renderGraph(fileName):
+    dot_path = shutil.which('dot') or 'dot'
+    subprocess.run(
+        [dot_path, '-Tsvg', '{0}.dot'.format(fileName), '-o', '{0}.svg'.format(fileName)],
+        check=True,
+        shell=False)
+
+
 def createBiPartite(rules, transformations, fileName, reactionCenter=True, 
                     context=True, products=True):
     '''
@@ -275,8 +283,7 @@ ranksep='1.5',rankdir='LR',compound='true')
     #graph = pgv.AGraph('%s.dot' % fileName)
     #graph.layout(prog='fdp')
     #graph.draw('%s.png' % fileName)
-    dot_path = shutil.which('dot') or 'dot'
-    subprocess.call([dot_path, '-Tsvg', './{0}.dot'.format(fileName), '-o', './{0}.svg'.format(fileName)], shell=False)
+    renderGraph(fileName)
     
 
 def addAnnotations(fileName):

--- a/parsers/ContactMap/server.py
+++ b/parsers/ContactMap/server.py
@@ -19,7 +19,6 @@ try:
 except ImportError:
     pass
 
-import threading
 import subprocess
 import createGraph
 import pexpect
@@ -27,58 +26,45 @@ try:
     import xmlrpclib  # nosec
 except ImportError:
     import xmlrpc.client as xmlrpclib  # nosec
-import glob
 import os
+import tempfile
 # Restrict to a particular path.
 class RequestHandler(SimpleXMLRPCRequestHandler):
     rpc_paths = ('/RPC2',)
 
 # Create server
 
-
-
-iid = 1
-iid_lock = threading.Lock()
-
-def next_id():
-    global iid
-    with iid_lock:
-        result = iid
-        iid += 1
-    return result   
-
-
 class BipartiteServer:
     
     def __init__(self):
         pass
     def bipartite(self, bbnglFile,returnType,center,context,product):
-        counter = next_id()
         print(center,context,product)
-        bnglFile = bbnglFile.data
-        with open('temp{0}.bngl'.format(counter),'w') as f:
-            f.write(bnglFile)
-        xmlFile = self._bngl2xml('temp{0}.bngl'.format(counter))
-        createGraph.processBNGL('temp{0}.xml'.format(counter),center,context,product)
-        with open('temp{0}.xml.dot'.format(counter),'rb') as f:
-            dot = f.read()
-        with open('temp{0}.xml.png'.format(counter),'rb') as f:
-            png = f.read()
-        for f in glob.glob('temp{0}*'.format(counter)):
-            try:
-                os.remove(f)
-            except OSError:
-                pass
+        bngl_data = bbnglFile.data
+        with tempfile.TemporaryDirectory(prefix='bionetgen-contactmap-') as temp_dir:
+            bngl_path = os.path.join(temp_dir, 'input.bngl')
+            xml_path = os.path.join(temp_dir, 'input.xml')
+            with open(bngl_path, 'w') as f:
+                f.write(bngl_data)
+            self._bngl2xml(bngl_path, temp_dir)
+            createGraph.processBNGL(xml_path, center, context, product)
+            with open(xml_path + '.dot', 'rb') as f:
+                dot = f.read()
+            with open(xml_path + '.svg', 'rb') as f:
+                svg = f.read()
         if returnType == 'dot':
             data = xmlrpclib.Binary(dot)
         else:
-            data = xmlrpclib.Binary(png)
+            data = xmlrpclib.Binary(svg)
         return data
 
     def getTransformations(self,bbnglFile):
         pass
-    def _bngl2xml(self,bnglFile):
-        subprocess.call(['bngdev', bnglFile, '--xml'], shell=False)
+    def _bngl2xml(self, bnglFile, output_dir):
+        subprocess.run(
+            ['bngdev', bnglFile, '--xml', '--outdir', output_dir],
+            check=True,
+            shell=False)
         
         
 

--- a/parsers/ContactMap/tests/test_createGraph.py
+++ b/parsers/ContactMap/tests/test_createGraph.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import sys
 import os
 
@@ -28,6 +28,17 @@ class MockAtomic:
         self.molecules = molecules
 
 class TestCreateGraph(unittest.TestCase):
+    @patch('createGraph.shutil.which', return_value='/usr/bin/dot')
+    @patch('createGraph.subprocess.run')
+    def test_rendering_uses_absolute_graph_paths(self, mock_run, mock_which):
+        createGraph.renderGraph('/tmp/contact-map/input.xml')
+        mock_which.assert_called_once_with('dot')
+        mock_run.assert_called_once_with(
+            ['/usr/bin/dot', '-Tsvg', '/tmp/contact-map/input.xml.dot',
+             '-o', '/tmp/contact-map/input.xml.svg'],
+            check=True,
+            shell=False)
+
     def test_extractMolecules_empty(self):
         """Test with an empty chemical array."""
         atomicPatterns, reactionCenter, context = createGraph.extractMolecules('action', 'site1', 'site2', [])

--- a/parsers/ContactMap/tests/test_server.py
+++ b/parsers/ContactMap/tests/test_server.py
@@ -1,7 +1,10 @@
 import unittest
-from unittest.mock import patch, MagicMock, mock_open
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch, MagicMock
 import sys
 import os
+import tempfile
+import threading
 
 # Mock dependencies before import to avoid errors since this runs in a constrained environment
 sys.modules['pexpect'] = MagicMock()
@@ -16,38 +19,130 @@ import server
 
 class TestServer(unittest.TestCase):
 
-    @patch('server.os.remove')
-    @patch('server.glob.glob')
-    @patch('builtins.open', new_callable=mock_open, read_data=b'dummy')
-    @patch('server.createGraph')
-    @patch.object(server.BipartiteServer, '_bngl2xml')
-    def test_bipartite_oserror_path(self, mock__bngl2xml, mock_createGraph, mock_file, mock_glob, mock_remove):
-        """
-        Tests the error path in bipartite where os.remove throws an OSError,
-        verifying that it is caught and ignored gracefully.
-        """
-        # Mock glob to return some files that will be "deleted"
-        mock_glob.return_value = ['temp1.bngl', 'temp1.xml', 'temp1.xml.dot', 'temp1.xml.png']
+    @staticmethod
+    def _request_file():
+        request = MagicMock()
+        request.data = 'dummy bngl data'
+        return request
 
-        # Make os.remove raise an OSError to simulate permission denied or file not found
-        mock_remove.side_effect = OSError("Mocked OSError")
+    @staticmethod
+    def _write_outputs(bngl_path, output_dir, converted):
+        if os.path.dirname(bngl_path) != output_dir:
+            raise AssertionError('conversion path is outside its temporary directory')
+        with open(bngl_path, 'r') as handle:
+            converted.append((bngl_path, handle.read()))
+        with open(os.path.splitext(bngl_path)[0] + '.xml', 'w') as handle:
+            handle.write('<xml />')
 
-        # Set up a mock bbnglFile object
-        mock_bbnglFile = MagicMock()
-        mock_bbnglFile.data = "dummy bngl data"
+    @staticmethod
+    def _write_graph_outputs(xml_path, processed):
+        processed.append(xml_path)
+        with open(xml_path + '.dot', 'wb') as handle:
+            handle.write(b'dummy dot')
+        with open(xml_path + '.svg', 'wb') as handle:
+            handle.write(b'dummy svg')
 
-        srv = server.BipartiteServer()
+    def test_bipartite_uses_isolated_files_and_cleans_on_success(self):
+        converted = []
+        processed = []
+        with tempfile.TemporaryDirectory() as parent:
+            with patch.object(server.tempfile, 'gettempdir', return_value=parent), \
+                    patch.object(server.BipartiteServer, '_bngl2xml',
+                                 side_effect=lambda path, output_dir: self._write_outputs(path, output_dir, converted)), \
+                    patch.object(server.createGraph, 'processBNGL',
+                                 side_effect=lambda path, *args: self._write_graph_outputs(path, processed)):
+                result = server.BipartiteServer().bipartite(
+                    self._request_file(), 'dot', 'center', 'context', 'product')
 
-        # Test bipartite with 'dot' returnType
-        # The OSError should be caught gracefully without crashing
-        result = srv.bipartite(mock_bbnglFile, 'dot', 'center', 'context', 'product')
+            self.assertIsInstance(result, server.xmlrpclib.Binary)
+            self.assertEqual(result.data, b'dummy dot')
+            self.assertEqual(len(converted), 1)
+            self.assertEqual(len(processed), 1)
+            self.assertFalse(os.path.exists(os.path.dirname(converted[0][0])))
+            self.assertEqual(os.listdir(parent), [])
 
-        # Verify the returned object is a Binary object as expected
-        self.assertIsInstance(result, server.xmlrpclib.Binary)
-        self.assertEqual(result.data, b'dummy')
+    def test_bipartite_returns_svg_for_non_dot_requests(self):
+        with tempfile.TemporaryDirectory() as parent:
+            with patch.object(server.tempfile, 'gettempdir', return_value=parent), \
+                    patch.object(server.BipartiteServer, '_bngl2xml',
+                                 side_effect=lambda path, output_dir: self._write_outputs(path, output_dir, [])), \
+                    patch.object(server.createGraph, 'processBNGL',
+                                 side_effect=lambda path, *args: self._write_graph_outputs(path, [])):
+                result = server.BipartiteServer().bipartite(
+                    self._request_file(), 'svg', 'center', 'context', 'product')
 
-        # Verify os.remove was called for each file returned by glob
-        self.assertEqual(mock_remove.call_count, 4)
+            self.assertIsInstance(result, server.xmlrpclib.Binary)
+            self.assertEqual(result.data, b'dummy svg')
+
+    def test_bipartite_cleans_on_conversion_failure(self):
+        converted = []
+
+        def fail_conversion(path, output_dir):
+            converted.append(path)
+            self.assertEqual(os.path.dirname(path), output_dir)
+            self.assertTrue(os.path.isfile(path))
+            raise RuntimeError('conversion failed')
+
+        with tempfile.TemporaryDirectory() as parent:
+            with patch.object(server.tempfile, 'gettempdir', return_value=parent), \
+                    patch.object(server.BipartiteServer, '_bngl2xml', side_effect=fail_conversion):
+                with self.assertRaisesRegex(RuntimeError, 'conversion failed'):
+                    server.BipartiteServer().bipartite(
+                        self._request_file(), 'dot', 'center', 'context', 'product')
+
+            self.assertEqual(len(converted), 1)
+            self.assertFalse(os.path.exists(os.path.dirname(converted[0])))
+            self.assertEqual(os.listdir(parent), [])
+
+    @patch.object(server.subprocess, 'run')
+    def test_bngl2xml_uses_private_output_directory_and_checks_errors(self, mock_run):
+        server.BipartiteServer()._bngl2xml('/tmp/input.bngl', '/tmp/output')
+        mock_run.assert_called_once_with(
+            ['bngdev', '/tmp/input.bngl', '--xml', '--outdir', '/tmp/output'],
+            check=True,
+            shell=False)
+
+    def test_concurrent_bipartite_requests_use_distinct_directories(self):
+        converted = []
+        processed = []
+        lock = threading.Lock()
+
+        def convert(path, output_dir):
+            if os.path.dirname(path) != output_dir:
+                raise AssertionError('conversion path is outside its temporary directory')
+            with open(path, 'r') as handle:
+                contents = handle.read()
+            with lock:
+                converted.append((path, contents))
+            with open(os.path.splitext(path)[0] + '.xml', 'w') as handle:
+                handle.write('<xml />')
+
+        def process(xml_path, *args):
+            with lock:
+                processed.append(xml_path)
+            with open(xml_path + '.dot', 'wb') as handle:
+                handle.write(b'dot')
+            with open(xml_path + '.svg', 'wb') as handle:
+                handle.write(b'svg')
+
+        with tempfile.TemporaryDirectory() as parent:
+            with patch.object(server.tempfile, 'gettempdir', return_value=parent), \
+                    patch.object(server.BipartiteServer, '_bngl2xml', side_effect=convert), \
+                    patch.object(server.createGraph, 'processBNGL', side_effect=process):
+                srv = server.BipartiteServer()
+                with ThreadPoolExecutor(max_workers=8) as executor:
+                    results = list(executor.map(
+                        lambda _: srv.bipartite(
+                            self._request_file(), 'dot', 'center', 'context', 'product'),
+                        range(8)))
+
+            self.assertEqual([result.data for result in results], [b'dot'] * 8)
+            self.assertEqual(len(converted), 8)
+            self.assertEqual(len(processed), 8)
+            directories = {os.path.dirname(path) for path, _ in converted}
+            self.assertEqual(len(directories), 8)
+            self.assertTrue(all(not os.path.exists(path) for path in directories))
+            self.assertEqual(os.listdir(parent), [])
 
     def test_getTransformations(self):
         """

--- a/src/ast/ReactionRule.cpp
+++ b/src/ast/ReactionRule.cpp
@@ -823,6 +823,18 @@ bool verifyBondTopology(const BNGcore::PatternGraph& graph) {
 
 } // namespace
 
+// Pattern metadata points into the immutable rule pattern graphs. Keeping it
+// per rule avoids rebuilding the same molecule/component descriptions for
+// every embedding search and generated reaction.
+struct ReactionRule::PatternCache {
+    std::vector<PatternInfo> reactantInfo;
+    std::vector<PatternInfo> productInfo;
+};
+
+ReactionRule::~ReactionRule() = default;
+ReactionRule::ReactionRule(ReactionRule&&) noexcept = default;
+ReactionRule& ReactionRule::operator=(ReactionRule&&) noexcept = default;
+
 bool ReactionRule::ComponentRef::operator==(const ComponentRef& other) const {
     return std::tie(patternIndex, moleculeIndex, componentIndex) ==
            std::tie(other.patternIndex, other.moleculeIndex, other.componentIndex);
@@ -897,6 +909,10 @@ const std::vector<ReactionRule::TransformOp>& ReactionRule::getOperations() cons
 }
 
 void ReactionRule::initialize() {
+    patternCache_ = std::make_unique<PatternCache>();
+    patternCache_->reactantInfo = describePatterns(reactantPatterns_);
+    patternCache_->productInfo = describePatterns(productPatterns_);
+
     operations_.clear();
     productOnlyStateChanges_.clear();
     hasMoleculeTypeMismatch_ = false;
@@ -907,8 +923,8 @@ void ReactionRule::initialize() {
         return;
     }
 
-    const auto reactantInfo = describePatterns(reactantPatterns_);
-    const auto productInfo = describePatterns(productPatterns_);
+    const auto& reactantInfo = patternCache_->reactantInfo;
+    const auto& productInfo = patternCache_->productInfo;
     const auto reactantMolecules = flattenMolecules(reactantInfo);
     const auto productMolecules = flattenMolecules(productInfo);
 
@@ -1226,7 +1242,7 @@ std::vector<ReactionRule::EmbeddingResult> ReactionRule::findEmbeddingsForSpecie
     const Model* model) const {
     std::vector<EmbeddingResult> results;
     const auto& pattern = reactantPatterns_.at(patternIndex).getGraph();
-    const auto reactantInfo = describePatterns(reactantPatterns_);
+    const auto& reactantInfo = patternCache_->reactantInfo;
     std::unordered_set<std::string> seen;
     const bool debug = std::getenv("BNG_DEBUG_EMBEDDINGS") != nullptr;
 
@@ -1751,8 +1767,8 @@ bool ReactionRule::buildReaction(
     const std::function<bool(const SpeciesGraph&)>& productFilter,
     const Model* model) const {
     const bool debug = std::getenv("BNG_DEBUG_BUILD_RXN") != nullptr;
-    const auto reactantInfo = describePatterns(reactantPatterns_);
-    const auto productInfo = describePatterns(productPatterns_);
+    const auto& reactantInfo = patternCache_->reactantInfo;
+    const auto& productInfo = patternCache_->productInfo;
     std::vector<std::size_t> reactantIndices;
     reactantIndices.reserve(matchSet.size());
     std::string inferredCompartment;
@@ -2307,7 +2323,7 @@ bool ReactionRule::buildReaction(
             // should leave the other half of the complex as a product.
 
             // Delete matched molecules from aggregate graph
-            const auto reactantInfoLocal = describePatterns(reactantPatterns_);
+            const auto& reactantInfoLocal = patternCache_->reactantInfo;
             for (std::size_t pi = 0; pi < reactantPatterns_.size(); ++pi) {
                 for (const auto& molInfo : reactantInfoLocal[pi].molecules) {
                     auto* targetMol = matchSet[pi].map.mapf(molInfo.node);

--- a/src/ast/ReactionRule.cpp
+++ b/src/ast/ReactionRule.cpp
@@ -1466,13 +1466,14 @@ std::size_t ReactionRule::expandRule(
                     return 0;
                 }
                 auto product = Species(std::move(sg), 0.0, false, productPattern.getCompartment());
-                const auto exactIndex = speciesList.findExact(product);
+                std::string exact;
+                const auto exactIndex = speciesList.findExact(product, exact);
                 std::size_t index;
                 if (exactIndex) {
                     index = *exactIndex;
                 } else {
                     product.getSpeciesGraph().canonicalLabel();
-                    index = speciesList.add(std::move(product)).first;
+                    index = speciesList.addWithExactKey(std::move(product), std::move(exact)).first;
                 }
                 productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
                 productIndices.push_back(index);
@@ -2371,13 +2372,14 @@ bool ReactionRule::buildReaction(
                     }
                 }
                 auto prodSp = Species(std::move(productGraph), 0.0, false, compartmentToUse);
-                const auto exactIndex = speciesList.findExact(prodSp);
+                std::string exact;
+                const auto exactIndex = speciesList.findExact(prodSp, exact);
                 std::size_t index;
                 if (exactIndex) {
                     index = *exactIndex;
                 } else {
                     prodSp.getSpeciesGraph().canonicalLabel();
-                    index = speciesList.add(std::move(prodSp)).first;
+                    index = speciesList.addWithExactKey(std::move(prodSp), std::move(exact)).first;
                 }
                 productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
                 productIndices.push_back(index);
@@ -2638,13 +2640,14 @@ bool ReactionRule::buildReaction(
             // GPCR has 'l' bonded: the product pattern says 'l' should be unbound.
             // (Product pattern bond constraint check would go here in a future version)
             auto prodSp = Species(std::move(productGraph), 0.0, false, compartmentToUse);
-            const auto exactIndex = speciesList.findExact(prodSp);
+            std::string exact;
+            const auto exactIndex = speciesList.findExact(prodSp, exact);
             std::size_t index;
             if (exactIndex) {
                 index = *exactIndex;
             } else {
                 prodSp.getSpeciesGraph().canonicalLabel();
-                index = speciesList.add(std::move(prodSp)).first;
+                index = speciesList.addWithExactKey(std::move(prodSp), std::move(exact)).first;
             }
             productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
             productIndices.push_back(index);

--- a/src/ast/ReactionRule.cpp
+++ b/src/ast/ReactionRule.cpp
@@ -1465,7 +1465,15 @@ std::size_t ReactionRule::expandRule(
                 if (productFilter && !productFilter(sg)) {
                     return 0;
                 }
-                const auto [index, isNew] = speciesList.add(Species(sg, 0.0, false, productPattern.getCompartment()));
+                auto product = Species(std::move(sg), 0.0, false, productPattern.getCompartment());
+                const auto exactIndex = speciesList.findExact(product);
+                std::size_t index;
+                if (exactIndex) {
+                    index = *exactIndex;
+                } else {
+                    product.getSpeciesGraph().canonicalLabel();
+                    index = speciesList.add(std::move(product)).first;
+                }
                 productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
                 productIndices.push_back(index);
             }
@@ -2362,8 +2370,15 @@ bool ReactionRule::buildReaction(
                         }
                     }
                 }
-                auto prodSp = Species(productGraph, 0.0, false, compartmentToUse);
-                const auto [index, wasNew] = speciesList.add(std::move(prodSp));
+                auto prodSp = Species(std::move(productGraph), 0.0, false, compartmentToUse);
+                const auto exactIndex = speciesList.findExact(prodSp);
+                std::size_t index;
+                if (exactIndex) {
+                    index = *exactIndex;
+                } else {
+                    prodSp.getSpeciesGraph().canonicalLabel();
+                    index = speciesList.add(std::move(prodSp)).first;
+                }
                 productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
                 productIndices.push_back(index);
             }
@@ -2622,8 +2637,15 @@ bool ReactionRule::buildReaction(
             // GPCR(l,b!1,loc~cyt,s~P).Arrestin(b!1) from applying to species where
             // GPCR has 'l' bonded: the product pattern says 'l' should be unbound.
             // (Product pattern bond constraint check would go here in a future version)
-            auto prodSp = Species(productGraph, 0.0, false, compartmentToUse);
-            const auto [index, wasNew] = speciesList.add(std::move(prodSp));
+            auto prodSp = Species(std::move(productGraph), 0.0, false, compartmentToUse);
+            const auto exactIndex = speciesList.findExact(prodSp);
+            std::size_t index;
+            if (exactIndex) {
+                index = *exactIndex;
+            } else {
+                prodSp.getSpeciesGraph().canonicalLabel();
+                index = speciesList.add(std::move(prodSp)).first;
+            }
             productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
             productIndices.push_back(index);
         }
@@ -2825,5 +2847,3 @@ bool ReactionRule::passesProductFilters(const std::vector<SpeciesGraph>& product
 }
 
 } // namespace bng::ast
-
-

--- a/src/ast/ReactionRule.cpp
+++ b/src/ast/ReactionRule.cpp
@@ -1465,8 +1465,8 @@ std::size_t ReactionRule::expandRule(
                 if (productFilter && !productFilter(sg)) {
                     return 0;
                 }
-                productLabels.push_back(sg.canonicalLabel());
                 const auto [index, isNew] = speciesList.add(Species(sg, 0.0, false, productPattern.getCompartment()));
+                productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
                 productIndices.push_back(index);
             }
             std::sort(productLabels.begin(), productLabels.end());
@@ -2332,7 +2332,6 @@ bool ReactionRule::buildReaction(
                 if (productFilter && !productFilter(productGraph)) {
                     return false;
                 }
-                productLabels.push_back(productGraph.canonicalLabel());
                 std::string compartmentToUse;
                 if (!g_compartmentDimensions.empty()) {
                     std::set<std::string> surfaces, volumes;
@@ -2365,6 +2364,7 @@ bool ReactionRule::buildReaction(
                 }
                 auto prodSp = Species(productGraph, 0.0, false, compartmentToUse);
                 const auto [index, wasNew] = speciesList.add(std::move(prodSp));
+                productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
                 productIndices.push_back(index);
             }
         }
@@ -2535,7 +2535,6 @@ bool ReactionRule::buildReaction(
             if (productFilter && !productFilter(productGraph)) {
                 return false;
             }
-            productLabels.push_back(productGraph.canonicalLabel());
             // Perl-faithful inferSpeciesCompartment (SpeciesGraph.pm:795-893):
             // Collect unique 2D surfaces and 3D volumes from molecule compartments.
             // 0 surfaces: 1 volume → that volume; 0 volumes → undefined; >1 → first alphabetically
@@ -2625,6 +2624,7 @@ bool ReactionRule::buildReaction(
             // (Product pattern bond constraint check would go here in a future version)
             auto prodSp = Species(productGraph, 0.0, false, compartmentToUse);
             const auto [index, wasNew] = speciesList.add(std::move(prodSp));
+            productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
             productIndices.push_back(index);
         }
     }
@@ -2825,6 +2825,5 @@ bool ReactionRule::passesProductFilters(const std::vector<SpeciesGraph>& product
 }
 
 } // namespace bng::ast
-
 
 

--- a/src/ast/ReactionRule.cpp
+++ b/src/ast/ReactionRule.cpp
@@ -1466,14 +1466,13 @@ std::size_t ReactionRule::expandRule(
                     return 0;
                 }
                 auto product = Species(std::move(sg), 0.0, false, productPattern.getCompartment());
-                std::string exact;
-                const auto exactIndex = speciesList.findExact(product, exact);
+                const auto exactIndex = speciesList.findExact(product);
                 std::size_t index;
                 if (exactIndex) {
                     index = *exactIndex;
                 } else {
                     product.getSpeciesGraph().canonicalLabel();
-                    index = speciesList.addWithExactKey(std::move(product), std::move(exact)).first;
+                    index = speciesList.add(std::move(product)).first;
                 }
                 productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
                 productIndices.push_back(index);
@@ -2372,14 +2371,13 @@ bool ReactionRule::buildReaction(
                     }
                 }
                 auto prodSp = Species(std::move(productGraph), 0.0, false, compartmentToUse);
-                std::string exact;
-                const auto exactIndex = speciesList.findExact(prodSp, exact);
+                const auto exactIndex = speciesList.findExact(prodSp);
                 std::size_t index;
                 if (exactIndex) {
                     index = *exactIndex;
                 } else {
                     prodSp.getSpeciesGraph().canonicalLabel();
-                    index = speciesList.addWithExactKey(std::move(prodSp), std::move(exact)).first;
+                    index = speciesList.add(std::move(prodSp)).first;
                 }
                 productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
                 productIndices.push_back(index);
@@ -2640,14 +2638,13 @@ bool ReactionRule::buildReaction(
             // GPCR has 'l' bonded: the product pattern says 'l' should be unbound.
             // (Product pattern bond constraint check would go here in a future version)
             auto prodSp = Species(std::move(productGraph), 0.0, false, compartmentToUse);
-            std::string exact;
-            const auto exactIndex = speciesList.findExact(prodSp, exact);
+            const auto exactIndex = speciesList.findExact(prodSp);
             std::size_t index;
             if (exactIndex) {
                 index = *exactIndex;
             } else {
                 prodSp.getSpeciesGraph().canonicalLabel();
-                index = speciesList.addWithExactKey(std::move(prodSp), std::move(exact)).first;
+                index = speciesList.add(std::move(prodSp)).first;
             }
             productLabels.push_back(speciesList.get(index).getSpeciesGraph().canonicalLabel());
             productIndices.push_back(index);

--- a/src/ast/ReactionRule.hpp
+++ b/src/ast/ReactionRule.hpp
@@ -69,6 +69,11 @@ public:
         bool bidirectional,
         std::vector<SpeciesGraph> reactantPatterns = {},
         std::vector<SpeciesGraph> productPatterns = {});
+    ~ReactionRule();
+    ReactionRule(ReactionRule&&) noexcept;
+    ReactionRule& operator=(ReactionRule&&) noexcept;
+    ReactionRule(const ReactionRule&) = delete;
+    ReactionRule& operator=(const ReactionRule&) = delete;
 
     const std::string& getRuleName() const;
     const std::string& getLabel() const;
@@ -115,6 +120,8 @@ private:
     bool bidirectional_;
     std::vector<SpeciesGraph> reactantPatterns_;
     std::vector<SpeciesGraph> productPatterns_;
+    struct PatternCache;
+    mutable std::unique_ptr<PatternCache> patternCache_;
     std::vector<TransformOp> operations_;
     std::vector<std::vector<ReactionCenterRef>> reactionCenter_;
     mutable std::vector<std::vector<EmbeddingResult>> patternMatches_;

--- a/src/ast/SpeciesList.cpp
+++ b/src/ast/SpeciesList.cpp
@@ -50,11 +50,17 @@ bool SpeciesList::getCheckIso() const {
 }
 
 std::optional<std::size_t> SpeciesList::findExact(const Species& species) const {
+    std::string exact;
+    return findExact(species, exact);
+}
+
+std::optional<std::size_t> SpeciesList::findExact(const Species& species, std::string& exact) const {
+    exact.clear();
     if (!checkIso_) {
         return std::nullopt;
     }
 
-    const std::string exact = species.getSpeciesGraph().toStringForDedup();
+    exact = species.getSpeciesGraph().toStringForDedup();
     const auto exactBucket = indicesByExactString_.find(exact);
     if (exactBucket == indicesByExactString_.end()) {
         return std::nullopt;
@@ -77,9 +83,28 @@ std::pair<std::size_t, bool> SpeciesList::add(Species species) {
         return {index, true};
     }
 
+    return addChecked(std::move(species), {}, false);
+}
+
+std::pair<std::size_t, bool> SpeciesList::addWithExactKey(Species species, std::string exact) {
+    // When check_iso is disabled, skip all dedup and add unconditionally
+    if (!checkIso_) {
+        const std::size_t index = species_.size();
+        species.setIndex(index);
+        species_.push_back(std::move(species));
+        return {index, true};
+    }
+
+    return addChecked(std::move(species), std::move(exact), true);
+}
+
+std::pair<std::size_t, bool> SpeciesList::addChecked(
+    Species species, std::string exact, bool hasExact) {
     // Use compartment-aware string for dedup to distinguish species that differ
     // only by per-molecule compartments (e.g., Im@CP.NP vs Im@NU.NP).
-    std::string exact = species.getSpeciesGraph().toStringForDedup();
+    if (!hasExact) {
+        exact = species.getSpeciesGraph().toStringForDedup();
+    }
 
     // Fast path 1: exact string match (O(1))
     const auto exactBucket = indicesByExactString_.find(exact);

--- a/src/ast/SpeciesList.cpp
+++ b/src/ast/SpeciesList.cpp
@@ -49,6 +49,25 @@ bool SpeciesList::getCheckIso() const {
     return checkIso_;
 }
 
+std::optional<std::size_t> SpeciesList::findExact(const Species& species) const {
+    if (!checkIso_) {
+        return std::nullopt;
+    }
+
+    const std::string exact = species.getSpeciesGraph().toStringForDedup();
+    const auto exactBucket = indicesByExactString_.find(exact);
+    if (exactBucket == indicesByExactString_.end()) {
+        return std::nullopt;
+    }
+
+    for (const auto index : exactBucket->second) {
+        if (species_[index].getCompartment() == species.getCompartment()) {
+            return index;
+        }
+    }
+    return std::nullopt;
+}
+
 std::pair<std::size_t, bool> SpeciesList::add(Species species) {
     // When check_iso is disabled, skip all dedup and add unconditionally
     if (!checkIso_) {

--- a/src/ast/SpeciesList.cpp
+++ b/src/ast/SpeciesList.cpp
@@ -50,17 +50,11 @@ bool SpeciesList::getCheckIso() const {
 }
 
 std::optional<std::size_t> SpeciesList::findExact(const Species& species) const {
-    std::string exact;
-    return findExact(species, exact);
-}
-
-std::optional<std::size_t> SpeciesList::findExact(const Species& species, std::string& exact) const {
-    exact.clear();
     if (!checkIso_) {
         return std::nullopt;
     }
 
-    exact = species.getSpeciesGraph().toStringForDedup();
+    const std::string exact = species.getSpeciesGraph().toStringForDedup();
     const auto exactBucket = indicesByExactString_.find(exact);
     if (exactBucket == indicesByExactString_.end()) {
         return std::nullopt;
@@ -83,28 +77,9 @@ std::pair<std::size_t, bool> SpeciesList::add(Species species) {
         return {index, true};
     }
 
-    return addChecked(std::move(species), {}, false);
-}
-
-std::pair<std::size_t, bool> SpeciesList::addWithExactKey(Species species, std::string exact) {
-    // When check_iso is disabled, skip all dedup and add unconditionally
-    if (!checkIso_) {
-        const std::size_t index = species_.size();
-        species.setIndex(index);
-        species_.push_back(std::move(species));
-        return {index, true};
-    }
-
-    return addChecked(std::move(species), std::move(exact), true);
-}
-
-std::pair<std::size_t, bool> SpeciesList::addChecked(
-    Species species, std::string exact, bool hasExact) {
     // Use compartment-aware string for dedup to distinguish species that differ
     // only by per-molecule compartments (e.g., Im@CP.NP vs Im@NU.NP).
-    if (!hasExact) {
-        exact = species.getSpeciesGraph().toStringForDedup();
-    }
+    std::string exact = species.getSpeciesGraph().toStringForDedup();
 
     // Fast path 1: exact string match (O(1))
     const auto exactBucket = indicesByExactString_.find(exact);

--- a/src/ast/SpeciesList.cpp
+++ b/src/ast/SpeciesList.cpp
@@ -58,10 +58,9 @@ std::pair<std::size_t, bool> SpeciesList::add(Species species) {
         return {index, true};
     }
 
-    const std::string label = species.getSpeciesGraph().canonicalLabel();
     // Use compartment-aware string for dedup to distinguish species that differ
     // only by per-molecule compartments (e.g., Im@CP.NP vs Im@NU.NP).
-    const std::string exact = species.getSpeciesGraph().toStringForDedup();
+    std::string exact = species.getSpeciesGraph().toStringForDedup();
 
     // Fast path 1: exact string match (O(1))
     const auto exactBucket = indicesByExactString_.find(exact);
@@ -76,6 +75,21 @@ std::pair<std::size_t, bool> SpeciesList::add(Species species) {
             }
             return {index, false};
         }
+    }
+
+    // Canonical labeling is substantially more expensive than exact string
+    // serialization.  Only compute it after the exact-key fast path misses;
+    // product graphs are frequently exact duplicates of an existing species.
+    const std::string label = species.getSpeciesGraph().canonicalLabel();
+    // Canonical labeling may change node-index tie breakers used by the
+    // serializer, so use the canonicalized key for all fallback and insert
+    // paths for compartmented species. For unscoped species, the canonical
+    // label and structural fingerprint are the authoritative fallback keys;
+    // retaining the pre-label exact key avoids serializing every new species a
+    // second time. Exact hits returned above do not need this second
+    // serialization.
+    if (!species.getCompartment().empty()) {
+        exact = species.getSpeciesGraph().toStringForDedup();
     }
 
     // Fast path 2: canonical label match (O(1))

--- a/src/ast/SpeciesList.hpp
+++ b/src/ast/SpeciesList.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -11,6 +12,8 @@ namespace bng::ast {
 class SpeciesList {
 public:
     std::pair<std::size_t, bool> add(Species species);
+    // Check the exact compartment-aware key without canonicalizing the graph.
+    std::optional<std::size_t> findExact(const Species& species) const;
     const Species& get(std::size_t index) const;
     Species& get(std::size_t index);
     bool containsLabel(const std::string& canonicalLabel) const;

--- a/src/ast/SpeciesList.hpp
+++ b/src/ast/SpeciesList.hpp
@@ -12,8 +12,11 @@ namespace bng::ast {
 class SpeciesList {
 public:
     std::pair<std::size_t, bool> add(Species species);
+    // Insert using an exact key already computed by findExact().
+    std::pair<std::size_t, bool> addWithExactKey(Species species, std::string exact);
     // Check the exact compartment-aware key without canonicalizing the graph.
     std::optional<std::size_t> findExact(const Species& species) const;
+    std::optional<std::size_t> findExact(const Species& species, std::string& exact) const;
     const Species& get(std::size_t index) const;
     Species& get(std::size_t index);
     bool containsLabel(const std::string& canonicalLabel) const;
@@ -28,6 +31,7 @@ public:
     bool getCheckIso() const;
 
 private:
+    std::pair<std::size_t, bool> addChecked(Species species, std::string exact, bool hasExact);
     std::vector<Species> species_;
     std::unordered_map<std::string, std::vector<std::size_t>> indicesByLabel_;
     std::unordered_map<std::string, std::vector<std::size_t>> indicesByExactString_;

--- a/src/ast/SpeciesList.hpp
+++ b/src/ast/SpeciesList.hpp
@@ -12,11 +12,8 @@ namespace bng::ast {
 class SpeciesList {
 public:
     std::pair<std::size_t, bool> add(Species species);
-    // Insert using an exact key already computed by findExact().
-    std::pair<std::size_t, bool> addWithExactKey(Species species, std::string exact);
     // Check the exact compartment-aware key without canonicalizing the graph.
     std::optional<std::size_t> findExact(const Species& species) const;
-    std::optional<std::size_t> findExact(const Species& species, std::string& exact) const;
     const Species& get(std::size_t index) const;
     Species& get(std::size_t index);
     bool containsLabel(const std::string& canonicalLabel) const;
@@ -31,7 +28,6 @@ public:
     bool getCheckIso() const;
 
 private:
-    std::pair<std::size_t, bool> addChecked(Species species, std::string exact, bool hasExact);
     std::vector<Species> species_;
     std::unordered_map<std::string, std::vector<std::size_t>> indicesByLabel_;
     std::unordered_map<std::string, std::vector<std::size_t>> indicesByExactString_;

--- a/src/core/BNGcore.hpp
+++ b/src/core/BNGcore.hpp
@@ -106,12 +106,6 @@ namespace BNGcore
     ////
 
 
-    // template for negation of equality operator
-    template < class T >
-    bool  operator!= ( const T & x1, const T & x2 )
-    {   return !( x1 == x2 );   };
-
-
     ////
     ////
     ////
@@ -927,6 +921,26 @@ namespace BNGcore
             virtual int  map ( const Node & node ) const;
             virtual int  map ( const Node & node1, const Node & node2 ) const;             
     };
+
+    // Keep the legacy negation helpers scoped to BNGcore types.  A generic
+    // operator!= here is also considered by ADL for std:: types that contain
+    // a BNGcore type (for example std::reverse_iterator<Node**>), which is
+    // ambiguous with libc++'s standard comparison operators.
+    inline bool operator!=(const StateType& lhs, const StateType& rhs) {
+        return !(lhs == rhs);
+    }
+
+    inline bool operator!=(const State& lhs, const State& rhs) {
+        return !(lhs == rhs);
+    }
+
+    inline bool operator!=(const NodeType& lhs, const NodeType& rhs) {
+        return !(lhs == rhs);
+    }
+
+    inline bool operator!=(const Node& lhs, const Node& rhs) {
+        return !(lhs == rhs);
+    }
 
 
     ////

--- a/src/core/PatternGraph.cpp
+++ b/src/core/PatternGraph.cpp
@@ -25,6 +25,9 @@ PatternGraph::PatternGraph ( )
 }
 
 
+
+
+
 // Copy constructor
 PatternGraph::PatternGraph ( const PatternGraph & source )
 {
@@ -624,6 +627,16 @@ PatternGraph::find_canonical_order ( bool preserve_prior_order ) const
 
     node_const_iter_t              edge_iter;
     std::vector <Node*>::iterator  node_iter;
+
+    // There is no Nauty input or node index to construct for an empty graph.
+    // In particular, avoid indexing ptn[-1] below; empty SpeciesGraph values
+    // are valid inputs to SpeciesList.
+    if ( nodes.empty() )
+    {
+        label.clear();
+        canonical_flag = true;
+        return;
+    }
 
     // a map from node address to index.
     std::map <Node*,int>  node_index;
@@ -1229,6 +1242,3 @@ PatternGraph::split_connected ( patterngraph_container_t & split_graphs )
         connected_nodes.clear();
     }
 }
-
-
-

--- a/src/engine/OdeIntegrator.cpp
+++ b/src/engine/OdeIntegrator.cpp
@@ -1,6 +1,7 @@
 #include "OdeIntegrator.hpp"
 
 #include <algorithm>
+#include <cctype>
 
 #include <cmath>
 #include <fstream>
@@ -124,8 +125,6 @@ bool hasWordBoundaryMatch(const std::string& text, const std::string& target) {
     }
     return false;
 }
-
-
 
 } // anonymous namespace
 
@@ -540,9 +539,21 @@ void OdeIntegrator::compile() {
         bool isFunctional = crxn.isFunctional;  // May already be set by Sat/MM/Hill
         const auto& rateExpr = rxn.getRateExpression();
 
+        std::string lowerRawRL;
+        bool hasLowerRawRL = false;
+
+        auto ensureLowerRawRL = [&]() {
+            if (!hasLowerRawRL) {
+                lowerRawRL = rawRateLaw;
+                std::transform(lowerRawRL.begin(), lowerRawRL.end(), lowerRawRL.begin(), [](unsigned char c) { return std::tolower(c); });
+                hasLowerRawRL = true;
+            }
+        };
+
+        bool checkedFunctions = false;
+
         if (!isFunctional && rateExpr.has_value()) {
-            std::string lowerRawRL = rawRateLaw;
-            std::transform(lowerRawRL.begin(), lowerRawRL.end(), lowerRawRL.begin(), [](unsigned char c) { return std::tolower(c); });
+            ensureLowerRawRL();
             std::string timeStr = "time";
             if (lowerRawRL.find(timeStr) != std::string::npos) {
                 isFunctional = true;
@@ -568,6 +579,7 @@ void OdeIntegrator::compile() {
                         break;
                     }
                 }
+                checkedFunctions = true;
             }
 
             if (isFunctional) {
@@ -592,10 +604,8 @@ void OdeIntegrator::compile() {
             }
         }
 
-        if (!crxn.isFunctional) {
-            const std::string rawRL = rxn.getRateLaw();
-            std::string lowerRawRL = rawRL;
-            std::transform(lowerRawRL.begin(), lowerRawRL.end(), lowerRawRL.begin(), [](unsigned char c) { return std::tolower(c); });
+        if (!crxn.isFunctional && !checkedFunctions) {
+            ensureLowerRawRL();
 
             std::size_t fIdx = 0;
             for (const auto& func : model_.getFunctions()) {
@@ -606,7 +616,7 @@ void OdeIntegrator::compile() {
                     // compound expressions like "k * funcName()" are preserved.
                     ast::Expression funcExpr2 = ast::Expression::number(0.0);
                     try {
-                        funcExpr2 = parser::parseExpression(rawRL);
+                        funcExpr2 = parser::parseExpression(rawRateLaw);
                     } catch (...) {
                         // Fallback: use bare identifier if parsing fails
                         funcExpr2 = ast::Expression::identifier(func.getName());

--- a/tests/ast/test_SpeciesList.cpp
+++ b/tests/ast/test_SpeciesList.cpp
@@ -77,5 +77,12 @@ TEST_CASE("SpeciesList preserves compartment-aware deduplication", "[ast][Specie
     REQUIRE(exact.has_value());
     REQUIRE(exact.value() == first.first);
     REQUIRE_FALSE(probe.getSpeciesGraph().getGraph().is_canonical());
-    REQUIRE(list.size() == 2);
+
+    Species distinct = makeSpecies("MITO");
+    std::string exactKey;
+    REQUIRE_FALSE(list.findExact(distinct, exactKey).has_value());
+    REQUIRE_FALSE(exactKey.empty());
+    const auto keyed = list.addWithExactKey(std::move(distinct), std::move(exactKey));
+    REQUIRE(keyed.second);
+    REQUIRE(list.size() == 3);
 }

--- a/tests/ast/test_SpeciesList.cpp
+++ b/tests/ast/test_SpeciesList.cpp
@@ -77,12 +77,5 @@ TEST_CASE("SpeciesList preserves compartment-aware deduplication", "[ast][Specie
     REQUIRE(exact.has_value());
     REQUIRE(exact.value() == first.first);
     REQUIRE_FALSE(probe.getSpeciesGraph().getGraph().is_canonical());
-
-    Species distinct = makeSpecies("MITO");
-    std::string exactKey;
-    REQUIRE_FALSE(list.findExact(distinct, exactKey).has_value());
-    REQUIRE_FALSE(exactKey.empty());
-    const auto keyed = list.addWithExactKey(std::move(distinct), std::move(exactKey));
-    REQUIRE(keyed.second);
-    REQUIRE(list.size() == 3);
+    REQUIRE(list.size() == 2);
 }

--- a/tests/ast/test_SpeciesList.cpp
+++ b/tests/ast/test_SpeciesList.cpp
@@ -40,3 +40,37 @@ TEST_CASE("SpeciesList functionality", "[ast][SpeciesList]") {
         REQUIRE(list.size() == 1);
     }
 }
+
+TEST_CASE("SpeciesList preserves compartment-aware deduplication", "[ast][SpeciesList]") {
+    BNGcore::EntityType moleculeType("M", BNGcore::ENTITY_NODE_TYPE, BNGcore::NULL_STATE_TYPE);
+    BNGcore::EntityType componentType("site", BNGcore::COMPONENT_NODE_TYPE, BNGcore::NULL_STATE_TYPE);
+
+    auto makeSpecies = [&](const std::string& moleculeCompartment) {
+        BNGcore::PatternGraph graph;
+        BNGcore::Node molecule(moleculeType);
+        BNGcore::Node component(componentType);
+        auto* moleculeNode = graph.add_node(molecule);
+        auto* componentNode = graph.add_node(component);
+        moleculeNode->set_compartment(moleculeCompartment);
+        graph.add_edge(moleculeNode, componentNode);
+        return Species(
+            SpeciesGraph(std::move(graph), "NM"),
+            0.0,
+            false,
+            "NM");
+    };
+
+    Species cytosolic = makeSpecies("CP");
+    Species nuclear = makeSpecies("NU");
+    SpeciesList list;
+
+    const auto first = list.add(cytosolic);
+    const auto second = list.add(nuclear);
+    const auto duplicate = list.add(cytosolic);
+
+    REQUIRE(first.second);
+    REQUIRE(second.second);
+    REQUIRE_FALSE(duplicate.second);
+    REQUIRE(duplicate.first == first.first);
+    REQUIRE(list.size() == 2);
+}

--- a/tests/ast/test_SpeciesList.cpp
+++ b/tests/ast/test_SpeciesList.cpp
@@ -67,10 +67,15 @@ TEST_CASE("SpeciesList preserves compartment-aware deduplication", "[ast][Specie
     const auto first = list.add(cytosolic);
     const auto second = list.add(nuclear);
     const auto duplicate = list.add(cytosolic);
+    const Species probe = makeSpecies("CP");
+    const auto exact = list.findExact(probe);
 
     REQUIRE(first.second);
     REQUIRE(second.second);
     REQUIRE_FALSE(duplicate.second);
     REQUIRE(duplicate.first == first.first);
+    REQUIRE(exact.has_value());
+    REQUIRE(exact.value() == first.first);
+    REQUIRE_FALSE(probe.getSpeciesGraph().getGraph().is_canonical());
     REQUIRE(list.size() == 2);
 }

--- a/tests/test_ode_integrator.cpp
+++ b/tests/test_ode_integrator.cpp
@@ -84,6 +84,54 @@ TEST_CASE("OdeIntegrator handles destruction", "[OdeIntegrator]") {
     REQUIRE_NOTHROW(integrator.reset());
 }
 
+TEST_CASE("OdeIntegrator preserves case-insensitive rate classification", "[OdeIntegrator]") {
+    auto makeNetwork = [](const std::string& rateLaw) {
+        GeneratedNetwork network;
+        network.species.setCheckIso(false);
+
+        bng::ast::SpeciesGraph reactantGraph;
+        network.species.add(bng::ast::Species(reactantGraph, 1.0));
+
+        bng::ast::SpeciesGraph productGraph;
+        network.species.add(bng::ast::Species(productGraph, 0.0));
+
+        network.reactions.add(bng::ast::Rxn(
+            "R1", {0}, {1}, rateLaw, 1.0, "dummy_rule",
+            bng::ast::Expression::number(2.0)));
+        return network;
+    };
+
+    SECTION("time keyword casing remains functional") {
+        for (const auto& rateLaw : {std::string("time"), std::string("TIME"), std::string("Time")}) {
+            bng::ast::Model model;
+            auto network = makeNetwork(rateLaw);
+            OdeIntegrator integrator(model, network);
+
+            double state[] = {1.0, 0.0};
+            double derivatives[] = {0.0, 0.0};
+            integrator.derivs(0.0, state, derivatives);
+
+            REQUIRE_THAT(derivatives[0], Catch::Matchers::WithinAbs(-2.0, 1e-12));
+            REQUIRE_THAT(derivatives[1], Catch::Matchers::WithinAbs(2.0, 1e-12));
+        }
+    }
+
+    SECTION("mixed-case function names are matched without lowercasing") {
+        bng::ast::Model model;
+        model.addFunction(bng::ast::Function(
+            "rateFn", {}, bng::ast::Expression::number(1.0)));
+        auto network = makeNetwork("RATEFN");
+        OdeIntegrator integrator(model, network);
+
+        double state[] = {1.0, 0.0};
+        double derivatives[] = {0.0, 0.0};
+        integrator.derivs(0.0, state, derivatives);
+
+        REQUIRE_THAT(derivatives[0], Catch::Matchers::WithinAbs(-2.0, 1e-12));
+        REQUIRE_THAT(derivatives[1], Catch::Matchers::WithinAbs(2.0, 1e-12));
+    }
+}
+
 TEST_CASE("OdeIntegrator handles cvode simulation", "[OdeIntegrator]") {
     bng::ast::Model model;
     GeneratedNetwork network;

--- a/tests/test_pattern_graph.cpp
+++ b/tests/test_pattern_graph.cpp
@@ -210,6 +210,13 @@ TEST_CASE("PatternGraph canonical finding and fast merge", "[BNGcore][PatternGra
         REQUIRE(graph.is_canonical() == false);
     }
 
+    SECTION("Empty graph canonicalization is defined") {
+        PatternGraph graph;
+
+        REQUIRE(graph.get_label().empty());
+        REQUIRE(graph.is_canonical() == true);
+    }
+
     SECTION("quick_merge merges node collections") {
         PatternGraph graph1;
         PatternGraph graph2;


### PR DESCRIPTION
## Summary

This is a CPU-only optimization series for the native C++ network-generation
path exercised by the production models in `bng2/Models2`. On the fixed
paired matrix, the first retained exact-dedup milestone changed median CPU
time by `+0.081%` (`blbr`, noise floor), `-7.288%` (SHP2), `-3.210%`
(EGFR), and `-3.956%` (FcERI), with corresponding wall-time changes of
`-0.172%`, `-6.903%`, `-2.985%`, and `-3.938%`. Adding the immutable
reaction-pattern metadata cache produced a further median CPU reduction of
`2.317%`, `0.856%`, `1.014%`, and `1.116%` on those workloads. Negative
values mean the candidate was faster. The medium and large workloads provide
the performance justification; `blbr` is retained as a correctness/noise
check.

The final branch is `akutuva21/bionetgen:codex/portable-cpu-20260831` at
`305b7482febe3dd52ccd517fa4cd2e02504e834c`. The branch is cumulative from
the fork master and therefore also includes the fork-base ContactMap and
rate-normalization commits listed in the complete ledger below. No rejected
optimization remains in the final source behavior.

## Mechanism

- `src/ast/SpeciesList.cpp`/`.hpp` checks a compartment-aware exact key before
  invoking canonical labeling, while retaining the canonical-label and
  structural-fingerprint fallback paths.
- `src/ast/ReactionRule.cpp`/`.hpp` reuses exact product keys where safe and
  caches immutable reactant/product `PatternInfo` metadata per rule. The
  implementation preserves canonical product ordering, graph ownership, match
  ordering, and operation data.
- `src/core/PatternGraph.cpp` adds the empty-graph canonicalization guard, and
  `src/core/BNGcore.hpp` constrains legacy inequality overloads to BNGcore
  types for Apple Clang/libc++ portability.
- Focused tests cover compartment-aware deduplication, empty graphs, exact
  serializer behavior, and cached-rule lifecycle.

No public Python import, CLI form, generated-file format, numerical behavior,
or external dependency was changed.

## Benchmark and correctness evidence

Inputs were SHA-256 pinned:

```text
blbr.bngl             c3290588efecbd3be2e57d883e851d6b28edd0c39eed43a491aa5c20533b6e96
SHP2_base_model.bngl  790d51dc260f9b3da7cd214ea6290998c81ed4ab4bd2e0dd8f16c49eb8182a
egfr_net.bngl         843e07954d5df1bacc99e294a2d7518b41f4813992567edc2c47794cec10a1da
fceri_ji.bngl         fa31fe7375510bb3e05f2335719a71abc1a22ada75be3eb5a8d5a0c80f29227e
```

Release configuration was Apple Clang 21.0.0, arm64, `-O3 -DNDEBUG`, CMake
4.4.3, Catch2 3.4.0, ANTLR4 4.13.1, and SUNDIALS 7.6.0 on a 15-logical-CPU
Apple M5 Pro. The paired runner used fresh processes/directories, alternating
execution order, 20 or 40 repetitions, and recorded wall time, user/system
CPU time, maximum RSS, output sizes/hashes, counts, command lines, and
executable/input hashes.

The principal command was:

```sh
python3 Benchmarks/portable_cpu_benchmark.py \
  --executable-a /private/tmp/bng_cpp-baseline-46da45c4 \
  --executable-b /private/tmp/bng_cpp-candidate-exact-precheck-move \
  --model bng2/Models2/blbr.bngl \
  --model bng2/Models2/SHP2_base_model.bngl \
  --model bng2/Models2/egfr_net.bngl \
  --model bng2/Models2/fceri_ji.bngl \
  --repetitions 20 --timeout 30 \
  --output /private/tmp/portable_cpu_exact_precheck_move_20.json
```

All retained-candidate paired artifacts were byte-identical. Independent
Perl BNG2 comparison passed for EGFR and FcERI; the pre-existing SHP2 and
blbr reaction-count discrepancies remain documented rather than hidden.
Release CTest passed 80/80, ASan/UBSan CTest passed 80/80, and all four
production runs completed without sanitizer diagnostics. The full 41-model
repository harness produced 34 passes and seven pre-existing
reference/environment failures, recorded in
`Benchmarks/PORTABLE_CPU_PERFORMANCE.md`.

The detailed benchmark tables, profiles, output hashes, rejected alternatives,
and validation commands are in
`Benchmarks/PORTABLE_CPU_PERFORMANCE.md`.

## Commit-by-commit change ledger

This is the complete chronological list of commits after `upstream/master`
included in this branch. Per-commit timings are not additive; the speedups
above are end-to-end milestone measurements.

- `a8b25d08` — secure ContactMap temporary-file handling in
  `parsers/ContactMap/createGraph.py`, `server.py`, and their tests.
- `43a2603d` — cache ODE rate-law normalization in
  `src/engine/OdeIntegrator.cpp` with focused tests.
- `b0041062` — merge the current RuleWorld master into the fork master.
- `77c8bd8c` — constrain `BNGcore` inequality overloads for portable
  Apple-Clang/libc++ lookup.
- `46da45c4` — handle empty pattern-graph canonicalization and add regression
  coverage.
- `533ac26b` — skip canonical labels for exact product duplicates.
- `5291159d` — add compartment-aware species-deduplication coverage.
- `c1711e68` — add the reproducible paired CPU benchmark runner and initial
  performance report.
- `92ca4c03` — preserve canonical product ordering while using the exact-key
  deduplication fast path; add the lifecycle assertion.
- `1a20be6e` — correct the benchmark validation report and its recorded
  baseline/candidate evidence.
- `4957ab79` — record the rejected canonicalization experiment.
- `5551d24e` — record the rejected serializer experiment.
- `70acc9e2` — test reuse of exact deduplication keys across product
  insertion.
- `e08a9bd2` — revert the unsafe exact-key handoff while retaining the safe
  implementation.
- `cffadba2` — record final portable CPU validation and independent-reference
  results.
- `7ee2db11` — cache immutable reaction-pattern metadata in `ReactionRule`.
- `d7002abe` — record the metadata-cache validation matrix.
- `d252f772` — record the final branch audit.
- `305b7482` — correct the audit report's self-referential executable hash.

## Scope boundary

The remaining profile-dominant work is canonical/Nauty graph deduplication
and, for ODE-heavy models, CVODE SPGMR/finite-difference J-times. Material
CPU gains there require a broader canonical-certificate/deduplication
representation or solver-aware Jacobian/preconditioner redesign; those are
not hidden in this targeted compatibility-preserving series.
