### PR TITLE
perf: add opt-in isolated parallel batch runner

### DIFF
--- a/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
+++ b/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
@@ -374,3 +374,54 @@ explicitly directed that no pull request be opened against `RuleWorld` and no
 fork default-branch push be made. The final branch was pushed only to the
 fork; local Release, independent-reference, full-harness, and ASan/UBSan
 evidence above are the available validation for this no-PR delivery.
+
+## Separate opt-in parallel track
+
+The existing `codex/parallel-optin-20260901` branch adds
+`Benchmarks/parallel_batch.py`, an opt-in process-level launcher. Each model
+runs in an isolated child process and working directory, so native mutable
+graph state and generated files are not shared. The normal `bng_cpp` CLI and
+single-process behavior are unchanged. The launcher records commands, model
+and executable hashes, wall/CPU/RSS measurements, output sizes, and output
+hashes.
+
+The paired commands used the final launcher and executable hashes below. The
+models are deterministic network/ODE workloads, so no stochastic seed is
+needed for this matrix:
+
+```sh
+python3 /private/tmp/parallel_pair_benchmark.py \
+  --batch-script Benchmarks/parallel_batch.py \
+  --executable build/src/bng_cpp \
+  --workload small=bng2/Models2/blbr.bngl,bng2/Models2/SHP2_base_model.bngl \
+  --repetitions 20 --parallel-jobs 2 --timeout 60 \
+  --output /private/tmp/portable_parallel_batch_small_medium_20.json
+
+python3 /private/tmp/parallel_pair_benchmark.py \
+  --batch-script Benchmarks/parallel_batch.py \
+  --executable build/src/bng_cpp \
+  --workload large=bng2/Models2/egfr_net.bngl,bng2/Models2/fceri_ji.bngl \
+  --repetitions 20 --parallel-jobs 2 --timeout 60 \
+  --output /private/tmp/portable_parallel_batch_large_20.json
+```
+
+The launcher SHA-256 was
+`aeb709ff1d81675ee48372bc53f1471b296299284cbfc459820fe1c9675e5a39`; the
+Release executable SHA-256 was
+`c4eeb05df99869d34364671089df598c7ecfc5f700c70e957297e968cb9b4d15`.
+Paired reductions are baseline-minus-candidate, with positive values faster:
+
+| Batch | Wall median [IQR; min..max] | CPU user median [IQR; min..max] | RSS median [IQR; min..max] | Artifact equality |
+| --- | ---: | ---: | ---: | --- |
+| `blbr` + `SHP2_base_model` (20 pairs) | +13.614% [2.502; +7.061..+17.171] | -0.373% [3.034; -5.659..+4.401] | +0.410% [2.596; -2.852..+2.250] | 40/40 job maps equal |
+| `egfr_net` + `fceri_ji` (20 pairs) | +45.808% [0.567; +41.810..+46.931] | -2.267% [1.045; -9.392..-0.754] | -0.177% [0.416; -3.633..+1.641] | 40/40 job maps equal |
+
+The large-batch result is a material throughput win: all 20 pairs improved in
+wall time while aggregate CPU user time remained approximately conserved and
+all per-model `.net`, `.cdat`, and `.gdat` hashes matched. The small-batch
+result is also wall-positive but CPU-neutral, so this is retained as an
+opt-in batch-throughput facility, not as a claim that one model runs faster.
+The limitation is fundamental to this implementation: independent models
+can overlap, while a single model remains single-process and shared-state
+safe. Further scaling requires a larger independent workload batch or a
+broader thread-safe engine redesign.

--- a/Benchmarks/parallel_batch.py
+++ b/Benchmarks/parallel_batch.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Run independent BioNetGen models in isolated processes.
+
+This is intentionally a process-level, opt-in launcher.  Native BioNetGen
+execution has mutable/static graph state, so models are not run concurrently
+inside one bng_cpp process.  Each job receives its own working directory and
+therefore keeps the generated .net/.cdat/.gdat/etc. files independent.
+"""
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - Windows has no resource module
+    resource = None
+
+
+EXCLUDED_FILES = {"manifest.json", "stdout.log", "stderr.log"}
+
+
+def sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def run_job(index, executable, model, output_root, bng_args, timeout):
+    model_path = pathlib.Path(model).resolve()
+    job_dir = output_root / f"{index:03d}-{model_path.stem}"
+    job_dir.mkdir()
+    local_model = job_dir / model_path.name
+    shutil.copy2(model_path, local_model)
+    command = [executable, *bng_args, str(local_model)]
+
+    started = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=job_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+        )
+        returncode = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+    except subprocess.TimeoutExpired as exc:
+        returncode = 124
+        stdout = exc.stdout or ""
+        stderr = (exc.stderr or "") + "\nparallel batch timeout\n"
+
+    elapsed = time.perf_counter() - started
+    (job_dir / "stdout.log").write_text(stdout)
+    (job_dir / "stderr.log").write_text(stderr)
+
+    files = sorted(
+        path for path in job_dir.iterdir()
+        if path.is_file() and path.name != local_model.name and path.name not in EXCLUDED_FILES
+    )
+    return {
+        "index": index,
+        "model": str(model_path),
+        "model_sha256": sha256(model_path),
+        "command": command,
+        "returncode": returncode,
+        "wall_seconds": elapsed,
+        "output_root": str(job_dir),
+        "output_hashes": {path.name: sha256(path) for path in files},
+        "output_sizes": {path.name: path.stat().st_size for path in files},
+        "output_bytes": sum(path.stat().st_size for path in files),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--executable", required=True, help="bng_cpp executable")
+    parser.add_argument("--model", action="append", required=True, dest="models")
+    parser.add_argument("--jobs", type=int, default=1, help="maximum concurrent child processes")
+    parser.add_argument("--output-root", help="empty directory for isolated job outputs")
+    parser.add_argument("--timeout", type=float, default=300.0)
+    parser.add_argument(
+        "--bng-arg",
+        action="append",
+        default=[],
+        help="argument passed to every bng_cpp invocation (repeatable)",
+    )
+    args = parser.parse_args()
+
+    if args.jobs < 1:
+        parser.error("--jobs must be at least 1")
+
+    executable = str(pathlib.Path(args.executable).resolve())
+    if not os.access(executable, os.X_OK):
+        parser.error(f"executable is not runnable: {executable}")
+
+    models = [str(pathlib.Path(model).resolve()) for model in args.models]
+    for model in models:
+        if not pathlib.Path(model).is_file():
+            parser.error(f"model does not exist: {model}")
+
+    temporary_root = args.output_root is None
+    output_root = pathlib.Path(args.output_root).resolve() if args.output_root else pathlib.Path(
+        tempfile.mkdtemp(prefix="bng-parallel-")
+    )
+    output_root.mkdir(parents=True, exist_ok=True)
+    if any(output_root.iterdir()):
+        parser.error(f"output directory must be empty: {output_root}")
+
+    started = time.perf_counter()
+    before = resource.getrusage(resource.RUSAGE_CHILDREN) if resource else None
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(args.jobs, len(models))) as pool:
+        futures = [
+            pool.submit(run_job, index, executable, model, output_root, args.bng_arg, args.timeout)
+            for index, model in enumerate(models)
+        ]
+        results = [future.result() for future in futures]
+    after = resource.getrusage(resource.RUSAGE_CHILDREN) if resource else None
+
+    manifest = {
+        "executable": executable,
+        "executable_sha256": sha256(pathlib.Path(executable)),
+        "models": models,
+        "jobs": args.jobs,
+        "timeout_seconds": args.timeout,
+        "bng_args": args.bng_arg,
+        "wall_seconds": time.perf_counter() - started,
+        "cpu_user_seconds": (after.ru_utime - before.ru_utime) if resource else None,
+        "cpu_system_seconds": (after.ru_stime - before.ru_stime) if resource else None,
+        "max_rss": after.ru_maxrss if resource else None,
+        "temporary_output_root": temporary_root,
+        "results": results,
+    }
+    (output_root / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    print(json.dumps(manifest, indent=2))
+    return 0 if all(result["returncode"] == 0 for result in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

This PR adds an opt-in process-level batch launcher for independent native
BioNetGen workloads. On 20 alternating pairs of the two large production
models (`egfr_net` + `fceri_ji`), two isolated child processes reduced median
batch wall time from `1.186718 s` to `0.641722 s` (`+45.808%` faster; IQR
`0.567%`, range `+41.810..+46.931%`, 20/20 wins). Aggregate CPU user time
changed by `-2.267%` and maximum RSS by `-0.177%`, while every per-model
`.net`, `.cdat`, and `.gdat` hash matched. On the small/medium pair the wall
reduction was `+13.614%` over 20 pairs, with CPU user time effectively
neutral (`-0.373%`). Positive values are baseline-minus-candidate reductions.

The final head is `akutuva21/bionetgen:codex/parallel-optin-20260901` at
`e52e8e41751f389eb8187b7e6d0ab946f0e5b8e8`. It is stacked on the validated
portable CPU branch; inherited commits are listed below and described in
RuleWorld/bionetgen PR #329. This PR does not change the normal `bng_cpp`
CLI or in-process execution.

## Mechanism

`Benchmarks/parallel_batch.py` launches each model in an independent child
process with its own copied input and working directory. It uses a bounded
`ThreadPoolExecutor` only to coordinate processes, avoiding shared mutable
graph state. It preserves every native output file and writes a manifest with
commands, input/executable hashes, wall/CPU/RSS metrics, output sizes, and
output hashes. It supports `--jobs`, repeated `--model`, `--bng-arg`,
`--timeout`, and an empty `--output-root`.

This is a throughput optimization for batches of independent models, not a
claim of faster execution for one model. No external dependency or native
engine source change is required.

## Benchmark and correctness evidence

The final launcher SHA-256 was
`aeb709ff1d81675ee48372bc53f1471b296299284cbfc459820fe1c9675e5a39`; the
Release `bng_cpp` SHA-256 was
`c4eeb05df99869d34364671089df598c7ecfc5f700c70e957297e968cb9b4d15`.
The paired commands were:

```sh
python3 /private/tmp/parallel_pair_benchmark.py \
  --batch-script Benchmarks/parallel_batch.py \
  --executable build/src/bng_cpp \
  --workload small=bng2/Models2/blbr.bngl,bng2/Models2/SHP2_base_model.bngl \
  --repetitions 20 --parallel-jobs 2 --timeout 60 \
  --output /private/tmp/portable_parallel_batch_small_medium_20.json

python3 /private/tmp/parallel_pair_benchmark.py \
  --batch-script Benchmarks/parallel_batch.py \
  --executable build/src/bng_cpp \
  --workload large=bng2/Models2/egfr_net.bngl,bng2/Models2/fceri_ji.bngl \
  --repetitions 20 --parallel-jobs 2 --timeout 60 \
  --output /private/tmp/portable_parallel_batch_large_20.json
```

The runner alternated jobs-1/jobs-2 order and used fresh output roots for
every pair. All 40 job maps in each matrix were hash-identical. The launcher
passed Python syntax compilation and a real one-model smoke run; the native
Release build and inherited focused/full/sanitizer tests are recorded in
`Benchmarks/PORTABLE_CPU_PERFORMANCE.md`.

## Commit-by-commit change ledger

This branch contains the complete portable series, unchanged and described in
PR #329:

- `a8b25d08` — secure ContactMap temporary files.
- `43a2603d` — cache ODE rate-law normalization.
- `b0041062` — merge current RuleWorld master into the fork master.
- `77c8bd8c` — constrain BNGcore inequality overloads for portability.
- `46da45c4` — handle empty pattern-graph canonicalization.
- `533ac26b` — skip canonical labels for exact product duplicates.
- `5291159d` — test compartment-aware species deduplication.
- `c1711e68` — add the reproducible CPU benchmark runner/report.
- `92ca4c03` — preserve canonical product ordering in the dedup fast path.
- `1a20be6e` — correct the portable benchmark validation report.
- `4957ab79` — record the rejected canonicalization experiment.
- `5551d24e` — record the rejected serializer experiment.
- `70acc9e2` — reuse exact dedup keys across product insertion.
- `e08a9bd2` — revert the unsafe exact-key handoff.
- `cffadba2` — record final portable CPU validation.
- `7ee2db11` — cache immutable reaction-pattern metadata.
- `d7002abe` — record metadata-cache validation.
- `d252f772` — record the final branch audit.
- `305b7482` — correct the audit report's executable hash.

The parallel branch-specific commits are:

- `bedb1987` — add the isolated process batch launcher, including resource
  accounting, timeout handling, output preservation, and manifest hashing.
- `e52e8e41` — record the 20-pair small/medium and large/large throughput
  matrices, spread, and artifact equality.

Per-commit timings are not additive; the headline results are end-to-end
batch measurements.

## Scope boundary

The launcher intentionally does not parallelize one model inside a process,
because the native engine has mutable/static graph state. Broader scaling of a
single model requires a thread-safe engine/state redesign; GPU execution and
language rewrites are outside this PR.
