### PR TITLE
docs: split future perf/validation write-ups into per-branch files

### DIFF
--- a/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
+++ b/Benchmarks/PORTABLE_CPU_PERFORMANCE.md
@@ -1,5 +1,11 @@
 # Portable CPU performance report
 
+> **This file is a historical record (PRs #329-#333) and is no longer
+> appended to.** New performance/validation write-ups go in their own file
+> under [`Benchmarks/reports/`](reports/README.md), one per branch, to avoid
+> the repeated merge conflicts this file accumulated from parallel branches
+> editing its tail.
+
 ## Scope and result
 
 This series targets the native C++ network-generation path used by production

--- a/Benchmarks/README.md
+++ b/Benchmarks/README.md
@@ -2,6 +2,13 @@
 
 This directory contains scripts for benchmarking BioNetGen performance across different versions, branches, or commits.
 
+## Writing up a result
+
+If you're documenting a benchmark or validation run (not just using the
+scripts below), add a new file under [`reports/`](reports/README.md) named
+after your branch. Don't append to an existing report file — see
+`reports/README.md` for why.
+
 ## Quick Start
 
 ### Compare two branches/commits:

--- a/Benchmarks/reports/README.md
+++ b/Benchmarks/reports/README.md
@@ -1,0 +1,28 @@
+# Per-branch performance/validation reports
+
+Each performance-optimization or validation write-up (native network
+generation, ODE integration, canonical labeling, parallel batching, etc.)
+gets its own file in this directory, named after the source branch, e.g.:
+
+```
+Benchmarks/reports/graph-string-20260901.md
+Benchmarks/reports/ode-integration-20260901.md
+Benchmarks/reports/canonical-redesign-20260901.md
+```
+
+**When writing up a new benchmark/validation result, create a new file
+here — do not append to an existing report file, and do not append to
+`Benchmarks/PORTABLE_CPU_PERFORMANCE.md`.** That file predates this
+convention and accumulated conflicting appends from several branches
+developed in parallel (PRs #329-#333), since every branch edited the same
+tail of the same file. A new file per branch cannot collide with another
+branch's new file, so this removes the recurring merge conflict entirely.
+
+`Benchmarks/PORTABLE_CPU_PERFORMANCE.md` is kept as-is as the historical
+record of that series and is not being retroactively split.
+
+Each report should be self-contained: state the branch name and base
+commit, the mechanism changed, the exact benchmark command(s) run (see
+`Benchmarks/portable_cpu_benchmark.py --help`), and the correctness
+evidence (test results, independent-reference comparisons) alongside the
+performance numbers.


### PR DESCRIPTION
## Summary

- Every parallel optimization branch (PRs #329-#333) appended a new section to the tail of `Benchmarks/PORTABLE_CPU_PERFORMANCE.md`. Since they all edited the same location, every one of these PRs hit the same merge conflict against master, requiring manual resolution each time.
- Adds `Benchmarks/reports/` with a one-file-per-branch convention (see `Benchmarks/reports/README.md`) so future write-ups land in a new, uniquely-named file instead of a shared one — eliminating the recurring conflict.
- Marks `Benchmarks/PORTABLE_CPU_PERFORMANCE.md` as a historical record (PRs #329-#333) that is no longer appended to, with a pointer to the new convention. Its existing content is untouched.
- Adds a short pointer from `Benchmarks/README.md`.

## Test plan

- [x] Docs-only change; no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)