### PR TITLE
perf: add native isolated parallel batch mode

### DIFF
--- a/Benchmarks/reports/parallel-optin-20260901.md
+++ b/Benchmarks/reports/parallel-optin-20260901.md
@@ -1,0 +1,56 @@
+# Native parallel batch mode
+
+## Scope
+
+The follow-up to the original `codex/parallel-optin-20260901` benchmark branch
+adds a user-facing native batch mode to `bng_cpp`. The mode is opt-in and is
+intended for independent model files:
+
+```sh
+bng_cpp --parallel 2 --parallel-dir ./parallel-output \
+  model-a.bngl model-b.bngl
+```
+
+The existing single-model and multi-input sequential invocation paths are
+unchanged unless `--parallel` (or its `--jobs` alias) is supplied.
+
+## Mechanism
+
+The parent process validates the inputs, creates one empty output root, and
+stages each model into a numbered job directory. A bounded set of worker
+threads launches one child `bng_cpp` process per job. Each child changes to its
+job directory before execution, so generated `.net`, `.cdat`, `.gdat`, and
+related files remain separate. The parent prints the output directory for each
+job and returns failure if any child exits unsuccessfully.
+
+This is process-level parallelism by design. It does not run multiple models
+inside one native engine instance, whose graph and parser state is not
+thread-safe. `--check` and `--verbose` are forwarded to every child. If
+`--parallel-dir` is omitted, the output root is created under the platform
+temporary directory and its path is printed on completion. Requested output
+roots must be empty to prevent accidental overwrites.
+
+The staged input is a private copy of the model file. Models that depend on
+additional relative files should be prepared as self-contained model files or
+run through the existing benchmark-side launcher, which has the same staging
+boundary.
+
+## Validation
+
+The executable-level test `test_batch_runner` covers:
+
+* two independent models producing `.net` files in separate job directories;
+* private copies of both input model files; and
+* propagation of a malformed child model failure while a valid sibling still
+  completes.
+
+Focused command:
+
+```sh
+cmake --build build-codex --target bng_cpp --parallel 4
+cmake --build build-codex --target test_batch_runner --parallel 4
+ctest --test-dir build-codex -R 'batch' --output-on-failure
+```
+
+Observed result: both focused tests passed on macOS. The native Release build
+completed with the repository's existing SUNDIALS deprecation warnings.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 project(BioNetGen_CPP LANGUAGES C CXX)
 
+find_package(Threads REQUIRED)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(FETCHCONTENT_UPDATES_DISCONNECTED ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ add_library(bng_engine STATIC
     io/SscWriter.cpp
     actions/ActionDispatch.cpp
     console/Console.cpp
+    cli/BatchRunner.cpp
 )
 
 # Link SUNDIALS/CVODE from FetchContent
@@ -113,6 +114,7 @@ target_link_libraries(bng_engine PUBLIC
     sundials_sunlinsoldense_static
     sundials_sunlinsolspgmr_static
     sundials_sunmatrixdense_static
+    Threads::Threads
 )
 target_compile_definitions(bng_engine PUBLIC BNG_CPP_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 

--- a/src/cli/BatchRunner.cpp
+++ b/src/cli/BatchRunner.cpp
@@ -1,0 +1,328 @@
+#include "BatchRunner.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cctype>
+#include <cstring>
+#include <exception>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+#include <process.h>
+#else
+#include <cerrno>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace bng::cli {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+struct Job {
+    fs::path sourcePath;
+    fs::path workingDirectory;
+    fs::path localModelPath;
+};
+
+struct ChildResult {
+    int exitCode = 1;
+    std::string error;
+};
+
+std::string safeStem(const fs::path& path) {
+    std::string stem = path.stem().string();
+    for (char& character : stem) {
+        const auto value = static_cast<unsigned char>(character);
+        if (!std::isalnum(value) && character != '-' && character != '_') {
+            character = '_';
+        }
+    }
+    return stem.empty() ? "model" : stem;
+}
+
+fs::path makeOutputRoot(const fs::path& requested) {
+    if (!requested.empty()) {
+        const auto root = fs::absolute(requested).lexically_normal();
+        std::error_code error;
+        if (fs::exists(root, error) && !fs::is_directory(root, error)) {
+            throw std::runtime_error("parallel output root is not a directory: " + root.string());
+        }
+        fs::create_directories(root, error);
+        if (error) {
+            throw std::runtime_error("could not create parallel output root " + root.string() + ": " + error.message());
+        }
+        if (fs::directory_iterator(root, error) != fs::directory_iterator()) {
+            throw std::runtime_error("parallel output root must be empty: " + root.string());
+        }
+        if (error) {
+            throw std::runtime_error("could not inspect parallel output root " + root.string() + ": " + error.message());
+        }
+        return root;
+    }
+
+    const auto base = fs::temp_directory_path();
+    const auto timestamp = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+#if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+    const auto processId = static_cast<unsigned long long>(_getpid());
+#else
+    const auto processId = static_cast<unsigned long long>(getpid());
+#endif
+    for (unsigned int attempt = 0; attempt < 100; ++attempt) {
+        const auto name = "bng-cpp-parallel-" + std::to_string(processId) + "-"
+            + std::to_string(timestamp) + "-" + std::to_string(attempt);
+        const auto root = base / name;
+        std::error_code error;
+        if (fs::create_directory(root, error)) {
+            return root;
+        }
+        if (error && error != std::errc::file_exists) {
+            throw std::runtime_error("could not create parallel output root " + root.string() + ": " + error.message());
+        }
+    }
+    throw std::runtime_error("could not create a unique parallel output root");
+}
+
+fs::path resolveExecutable(const fs::path& executable) {
+    if (executable.empty()) {
+        throw std::runtime_error("parallel executable path is empty");
+    }
+    if (executable.has_parent_path() || fs::exists(executable)) {
+        return fs::absolute(executable).lexically_normal();
+    }
+    // A bare executable name is intentionally left for PATH lookup by execvp
+    // or _spawnvp after the child changes to its job directory.
+    return executable;
+}
+
+std::vector<Job> stageJobs(const ParallelBatchOptions& options, const fs::path& outputRoot) {
+    std::vector<Job> jobs;
+    jobs.reserve(options.inputs.size());
+    for (std::size_t index = 0; index < options.inputs.size(); ++index) {
+        const auto sourcePath = fs::absolute(options.inputs[index]).lexically_normal();
+        std::error_code error;
+        if (!fs::is_regular_file(sourcePath, error)) {
+            throw std::runtime_error("parallel input is not a regular file: " + sourcePath.string());
+        }
+
+        std::ostringstream directoryName;
+        directoryName << "job_" << std::setw(3) << std::setfill('0') << index
+                      << "-" << safeStem(sourcePath);
+        const auto workingDirectory = outputRoot / directoryName.str();
+        fs::create_directory(workingDirectory, error);
+        if (error) {
+            throw std::runtime_error("could not create parallel job directory "
+                + workingDirectory.string() + ": " + error.message());
+        }
+
+        const auto localModelPath = workingDirectory / sourcePath.filename();
+        fs::copy_file(sourcePath, localModelPath, fs::copy_options::none, error);
+        if (error) {
+            throw std::runtime_error("could not stage " + sourcePath.string() + ": " + error.message());
+        }
+        jobs.push_back({sourcePath, workingDirectory, localModelPath});
+    }
+    return jobs;
+}
+
+std::vector<std::string> childArguments(
+    const fs::path& executable,
+    const fs::path& localModelPath,
+    bool checkOnly,
+    bool verbose) {
+
+    std::vector<std::string> arguments;
+    arguments.reserve(4);
+    arguments.push_back(executable.string());
+    if (checkOnly) {
+        arguments.emplace_back("--check");
+    }
+    if (verbose) {
+        arguments.emplace_back("--verbose");
+    }
+    arguments.push_back(localModelPath.string());
+    return arguments;
+}
+
+int runChild(
+    const fs::path& executable,
+    const Job& job,
+    bool checkOnly,
+    bool verbose,
+    std::string& errorMessage) {
+
+    auto arguments = childArguments(executable, job.localModelPath, checkOnly, verbose);
+    std::vector<char*> nativeArguments;
+    nativeArguments.reserve(arguments.size() + 1);
+    for (auto& argument : arguments) {
+        nativeArguments.push_back(argument.data());
+    }
+    nativeArguments.push_back(nullptr);
+
+#if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+    // Windows has no fork/chdir-for-the-child primitive. The short critical
+    // section only covers changing the parent's cwd and spawning; waiting for
+    // the child happens after restoring it, so jobs still run concurrently.
+    static std::mutex spawnMutex;
+    intptr_t process = -1;
+    {
+        std::lock_guard<std::mutex> lock(spawnMutex);
+        std::error_code error;
+        const auto previousDirectory = fs::current_path(error);
+        if (error) {
+            errorMessage = "could not read current directory: " + error.message();
+            return 1;
+        }
+        fs::current_path(job.workingDirectory, error);
+        if (error) {
+            errorMessage = "could not enter " + job.workingDirectory.string() + ": " + error.message();
+            return 1;
+        }
+
+        const auto executableText = executable.string();
+        if (executable.has_parent_path()) {
+            process = _spawnv(_P_NOWAIT, executableText.c_str(), nativeArguments.data());
+        } else {
+            process = _spawnvp(_P_NOWAIT, executableText.c_str(), nativeArguments.data());
+        }
+        const auto restoreError = [&]() {
+            std::error_code restoreStatus;
+            fs::current_path(previousDirectory, restoreStatus);
+            return restoreStatus;
+        }();
+        if (restoreError) {
+            errorMessage = "could not restore current directory: " + restoreError.message();
+            return 1;
+        }
+        if (process == -1) {
+            errorMessage = "could not start child process";
+            return 1;
+        }
+    }
+
+    int status = 1;
+    if (_cwait(&status, process, 0) == -1) {
+        errorMessage = "could not wait for child process";
+        return 1;
+    }
+    return status;
+#else
+    const pid_t process = fork();
+    if (process == -1) {
+        errorMessage = std::strerror(errno);
+        return 1;
+    }
+    if (process == 0) {
+        if (chdir(job.workingDirectory.c_str()) != 0) {
+            _exit(126);
+        }
+        if (executable.has_parent_path()) {
+            execv(executable.c_str(), nativeArguments.data());
+        } else {
+            execvp(executable.c_str(), nativeArguments.data());
+        }
+        _exit(127);
+    }
+
+    int status = 0;
+    while (waitpid(process, &status, 0) == -1) {
+        if (errno != EINTR) {
+            errorMessage = std::strerror(errno);
+            return 1;
+        }
+    }
+    if (WIFEXITED(status)) {
+        return WEXITSTATUS(status);
+    }
+    if (WIFSIGNALED(status)) {
+        errorMessage = "child terminated by signal " + std::to_string(WTERMSIG(status));
+        return 128 + WTERMSIG(status);
+    }
+    errorMessage = "child ended in an unknown state";
+    return 1;
+#endif
+}
+
+} // namespace
+
+int runParallelBatch(const ParallelBatchOptions& options) {
+    if (options.inputs.empty()) {
+        std::cerr << "error: parallel mode requires at least one model\n";
+        return 1;
+    }
+    if (options.maxJobs == 0) {
+        std::cerr << "error: parallel job count must be greater than zero\n";
+        return 1;
+    }
+
+    try {
+        const auto executable = resolveExecutable(options.executable);
+        const auto outputRoot = makeOutputRoot(options.outputRoot);
+        const auto jobs = stageJobs(options, outputRoot);
+        const auto workerCount = std::min(options.maxJobs, jobs.size());
+        std::vector<ChildResult> results(jobs.size());
+        std::atomic<std::size_t> nextJob{0};
+        std::vector<std::thread> workers;
+        workers.reserve(workerCount);
+
+        for (std::size_t worker = 0; worker < workerCount; ++worker) {
+            workers.emplace_back([&]() {
+                while (true) {
+                    const auto index = nextJob.fetch_add(1);
+                    if (index >= jobs.size()) {
+                        return;
+                    }
+                    try {
+                        results[index].exitCode = runChild(
+                            executable, jobs[index], options.checkOnly, options.verbose, results[index].error);
+                    } catch (const std::exception& exception) {
+                        results[index].error = exception.what();
+                        results[index].exitCode = 1;
+                    }
+                }
+            });
+        }
+        for (auto& worker : workers) {
+            worker.join();
+        }
+
+        std::cout << "[bng_cpp] parallel batch outputs: " << outputRoot.string() << '\n';
+        std::size_t failures = 0;
+        for (std::size_t index = 0; index < results.size(); ++index) {
+            const auto& result = results[index];
+            std::cout << "[bng_cpp] parallel batch job " << index
+                      << " output: " << jobs[index].workingDirectory.string()
+                      << " exit=" << result.exitCode << '\n';
+            if (result.exitCode != 0) {
+                ++failures;
+                std::cerr << "[bng_cpp] parallel batch job " << index << " failed";
+                if (!result.error.empty()) {
+                    std::cerr << ": " << result.error;
+                }
+                std::cerr << '\n';
+            }
+        }
+        if (failures != 0) {
+            std::cerr << "[bng_cpp] parallel batch failed: " << failures
+                      << " of " << results.size() << " job(s)\n";
+            return 1;
+        }
+        return 0;
+    } catch (const std::exception& exception) {
+        std::cerr << "error: " << exception.what() << '\n';
+        return 1;
+    }
+}
+
+} // namespace bng::cli

--- a/src/cli/BatchRunner.hpp
+++ b/src/cli/BatchRunner.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <vector>
+
+namespace bng::cli {
+
+struct ParallelBatchOptions {
+    std::filesystem::path executable;
+    std::vector<std::filesystem::path> inputs;
+    std::size_t maxJobs = 1;
+    std::filesystem::path outputRoot;
+    bool checkOnly = false;
+    bool verbose = false;
+};
+
+/**
+ * Run independent model files in isolated child processes.
+ *
+ * Each child receives a private working directory and a private copy of its
+ * input model. This keeps generated files and native mutable graph state
+ * separate while allowing independent models to overlap.
+ */
+int runParallelBatch(const ParallelBatchOptions& options);
+
+} // namespace bng::cli

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,7 @@
 #include <fstream>
+#include <filesystem>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -9,6 +11,7 @@
 #include "BNGLexer.h"
 #include "BNGParser.h"
 #include "actions/ActionDispatch.hpp"
+#include "cli/BatchRunner.hpp"
 #include "console/Console.hpp"
 #include "parser/BNGAstVisitor.hpp"
 
@@ -56,8 +59,25 @@ ParseResult parseFile(const std::string& path) {
 }
 
 void printUsage() {
-    std::cerr << "Usage: bng_cpp [--check] [--verbose] [--version] [--console|-i] <model1.bngl> [model2.bngl ...]\n";
+    std::cerr << "Usage: bng_cpp [--check] [--verbose] [--version] [--console|-i] [--parallel JOBS] [--parallel-dir DIR] <model1.bngl> [model2.bngl ...]\n";
     std::cerr << "  --console, -i   Enter interactive console mode\n";
+    std::cerr << "  --parallel JOBS Run independent models in isolated child processes (alias: --jobs)\n";
+    std::cerr << "  --parallel-dir DIR  Store isolated job outputs under DIR\n";
+}
+
+bool parsePositiveSize(const std::string& value, std::size_t& result) {
+    try {
+        std::size_t consumed = 0;
+        const auto parsed = std::stoull(value, &consumed);
+        if (consumed != value.size() || parsed == 0
+            || parsed > static_cast<unsigned long long>(std::numeric_limits<std::size_t>::max())) {
+            return false;
+        }
+        result = static_cast<std::size_t>(parsed);
+        return true;
+    } catch (...) {
+        return false;
+    }
 }
 
 } // namespace
@@ -66,6 +86,8 @@ int main(int argc, char** argv) {
     bool checkOnly = false;
     bool verbose = false;
     bool consoleMode = false;
+    std::size_t parallelJobs = 0;
+    std::filesystem::path parallelDirectory;
     std::vector<std::string> inputs;
 
     for (int i = 1; i < argc; ++i) {
@@ -86,7 +108,47 @@ int main(int argc, char** argv) {
             consoleMode = true;
             continue;
         }
+        if (arg == "--parallel" || arg == "--jobs") {
+            if (i + 1 >= argc || !parsePositiveSize(argv[++i], parallelJobs)) {
+                std::cerr << "error: --parallel requires a positive integer job count\n";
+                return 1;
+            }
+            continue;
+        }
+        if (arg.rfind("--parallel=", 0) == 0 || arg.rfind("--jobs=", 0) == 0) {
+            const auto separator = arg.find('=');
+            if (!parsePositiveSize(arg.substr(separator + 1), parallelJobs)) {
+                std::cerr << "error: --parallel requires a positive integer job count\n";
+                return 1;
+            }
+            continue;
+        }
+        if (arg == "--parallel-dir") {
+            if (i + 1 >= argc) {
+                std::cerr << "error: --parallel-dir requires a directory\n";
+                return 1;
+            }
+            parallelDirectory = argv[++i];
+            continue;
+        }
+        if (arg.rfind("--parallel-dir=", 0) == 0) {
+            parallelDirectory = arg.substr(std::string("--parallel-dir=").size());
+            if (parallelDirectory.empty()) {
+                std::cerr << "error: --parallel-dir requires a directory\n";
+                return 1;
+            }
+            continue;
+        }
         inputs.push_back(arg);
+    }
+
+    if (parallelJobs != 0 && consoleMode) {
+        std::cerr << "error: --parallel cannot be combined with --console\n";
+        return 1;
+    }
+    if (parallelJobs == 0 && !parallelDirectory.empty()) {
+        std::cerr << "error: --parallel-dir requires --parallel\n";
+        return 1;
     }
 
     // Console mode: optionally load a model, then enter REPL
@@ -112,6 +174,19 @@ int main(int argc, char** argv) {
     if (inputs.empty()) {
         printUsage();
         return 1;
+    }
+
+    if (parallelJobs != 0) {
+        bng::cli::ParallelBatchOptions options;
+        options.executable = argv[0];
+        options.maxJobs = parallelJobs;
+        options.outputRoot = parallelDirectory;
+        options.checkOnly = checkOnly;
+        options.verbose = verbose;
+        for (const auto& input : inputs) {
+            options.inputs.emplace_back(input);
+        }
+        return bng::cli::runParallelBatch(options);
     }
 
     int failures = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -321,3 +321,12 @@ target_include_directories(test_michaelis_menten PRIVATE
 )
 target_link_libraries(test_michaelis_menten PRIVATE Catch2::Catch2WithMain Catch2::Catch2 bng_ast)
 catch_discover_tests(test_michaelis_menten)
+
+add_executable(test_batch_runner test_batch_runner.cpp)
+target_compile_definitions(test_batch_runner PRIVATE
+    BNG_CPP_PATH="$<TARGET_FILE:bng_cpp>"
+    BNG_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+)
+target_link_libraries(test_batch_runner PRIVATE Catch2::Catch2WithMain Catch2::Catch2 bng_engine)
+add_dependencies(test_batch_runner bng_cpp)
+catch_discover_tests(test_batch_runner)

--- a/tests/test_batch_runner.cpp
+++ b/tests/test_batch_runner.cpp
@@ -1,0 +1,80 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace {
+
+namespace fs = std::filesystem;
+
+fs::path testRoot() {
+    const auto stamp = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    return fs::temp_directory_path() / ("bng-cpp-batch-test-" + std::to_string(stamp));
+}
+
+std::string shellQuote(const fs::path& path) {
+#if defined(_WIN32) || defined(__WIN32__) || defined(__CYGWIN__)
+    return "\"" + path.string() + "\"";
+#else
+    std::string quoted = "'";
+    for (const char character : path.string()) {
+        if (character == '\'') {
+            quoted += "'\\''";
+        } else {
+            quoted += character;
+        }
+    }
+    quoted += "'";
+    return quoted;
+#endif
+}
+
+int runCommand(const std::string& command) {
+    return std::system(command.c_str());
+}
+
+} // namespace
+
+TEST_CASE("bng_cpp parallel mode isolates model outputs", "[batch]") {
+    const auto root = testRoot();
+    const auto outputRoot = root / "outputs";
+    fs::create_directories(root);
+
+    const auto modelOne = fs::path(BNG_SOURCE_DIR) / "bng2" / "Models2" / "LV.bngl";
+    const auto modelTwo = fs::path(BNG_SOURCE_DIR) / "bng2" / "Validate" / "blbr.bngl";
+    const auto command = shellQuote(fs::path(BNG_CPP_PATH))
+        + " --parallel 2 --parallel-dir " + shellQuote(outputRoot)
+        + " " + shellQuote(modelOne) + " " + shellQuote(modelTwo);
+
+    REQUIRE(runCommand(command) == 0);
+    REQUIRE(fs::exists(outputRoot / "job_000-LV" / "LV.net"));
+    REQUIRE(fs::exists(outputRoot / "job_001-blbr" / "blbr.net"));
+    REQUIRE(fs::exists(outputRoot / "job_000-LV" / "LV.bngl"));
+    REQUIRE(fs::exists(outputRoot / "job_001-blbr" / "blbr.bngl"));
+
+    fs::remove_all(root);
+}
+
+TEST_CASE("bng_cpp parallel mode propagates child failures", "[batch]") {
+    const auto root = testRoot();
+    const auto outputRoot = root / "outputs";
+    const auto invalidModel = root / "invalid.bngl";
+    fs::create_directories(root);
+    {
+        std::ofstream output(invalidModel);
+        output << "this is not a BioNetGen model\n";
+    }
+
+    const auto validModel = fs::path(BNG_SOURCE_DIR) / "bng2" / "Models2" / "LV.bngl";
+    const auto command = shellQuote(fs::path(BNG_CPP_PATH))
+        + " --parallel 2 --parallel-dir " + shellQuote(outputRoot)
+        + " " + shellQuote(validModel) + " " + shellQuote(invalidModel);
+
+    REQUIRE(runCommand(command) != 0);
+    REQUIRE(fs::exists(outputRoot / "job_000-LV" / "LV.net"));
+
+    fs::remove_all(root);
+}


### PR DESCRIPTION
## Summary

PR #333 added a benchmark-side process launcher but intentionally left the native `bng_cpp` CLI unchanged. This follow-up implements the documented optimization in the executable itself.

`bng_cpp --parallel JOBS model-a.bngl model-b.bngl` now runs independent models in bounded isolated child processes. Each job gets a private working directory and staged input copy, so generated artifacts and mutable native graph state are not shared. `--parallel-dir` makes the output root explicit; otherwise the path is printed under the platform temporary directory.

Single-model and sequential multi-input behavior remain unchanged unless parallel mode is explicitly requested. `--check` and `--verbose` are forwarded to child processes, and the parent returns failure when any child fails. `--jobs` is supported as an alias for `--parallel`.

## Changes

- Added portable `BatchRunner` implementation with POSIX fork/exec and Windows spawn support.
- Added safe empty-output-root validation and numbered per-job output directories.
- Added bounded scheduling, child exit-status propagation, and output-directory reporting.
- Added CTest coverage for output isolation, staged inputs, and sibling failure propagation.
- Added a per-branch implementation and validation report.

## Validation

- `cmake --build build-codex --target bng_cpp --parallel 4`
- `cmake --build build-codex --target test_batch_runner --parallel 4`
- `ctest --test-dir build-codex --output-on-failure --parallel 4` — 83/83 passed
- Real two-large-model smoke run (`egfr_net` + `fceri_ji`) completed successfully with separate output directories.

Base synchronized to current upstream `master` before implementation.